### PR TITLE
feat(domain): LabProjectにoperatorフィールドを追加し，GroupTypeのロール重複バリデーションを実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ astro.config.d.mts
 storybook-static
 vite.config.*.timestamp*
 vitest.config.*.timestamp*
+
+.ai

--- a/apps/backend/src/domain/group.rs
+++ b/apps/backend/src/domain/group.rs
@@ -15,29 +15,79 @@ pub enum UpdateRolesError {
     InvalidInput(String),
 }
 
+/// 団体の種類と団体固有のフィールドを持つ列挙型です．
+/// 各団体の種類の詳細については委員内ドキュメント(JIZI Wikiなど)を参照してください．
+/// 主な固有フィールドとしてメンバーのロールがありますが，団体への所属自体は `Membership` を用いて表現します．
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum GroupType {
+    /// 学内取材団体．一人の代表者を持つ．
     Press {
         representative: UserId,
     },
+    /// 一般企画団体．第一責任者から第三責任者まで計３名のメンバーを持つ．
+    /// 第一責任者から第三責任者には別のメンバーが割り当てられる必要がある．
     GeneralProject {
         representative1: UserId,
         representative2: UserId,
         representative3: UserId,
     },
+    /// 模擬店企画団体．第一責任者から第三責任者まで計３名のメンバーを持つ．
+    /// 第一責任者から第三責任者には別のメンバーが割り当てられる必要がある．
     BoothProject {
         representative1: UserId,
         representative2: UserId,
         representative3: UserId,
     },
+    /// 研究室企画団体．企画責任者と企画実施担当者を持つ．
+    /// 企画責任者と企画実施担当者は兼任可能(同一のユーザーIDを代入可能)．
     LabProject {
         representative: UserId,
+        operator: UserId,
     },
+    /// ステージ企画団体．第一責任者から第三責任者まで計３名のメンバーを持つ．
+    /// 第一責任者から第三責任者には別のメンバーが割り当てられる必要がある．
     StageProject {
         representative1: UserId,
         representative2: UserId,
         representative3: UserId,
     },
+}
+
+impl GroupType {
+    /// GroupTypeのフィールドが正しく設定されているかを検証します．
+    ///
+    /// # Errors
+    /// - `FactoryError::InvalidInput` - 責任者の重複など，不正な入力が行われた場合に発生します．
+    fn validate(&self) -> Result<(), FactoryError> {
+        match self {
+            GroupType::GeneralProject {
+                representative1,
+                representative2,
+                representative3,
+            }
+            | GroupType::BoothProject {
+                representative1,
+                representative2,
+                representative3,
+            }
+            | GroupType::StageProject {
+                representative1,
+                representative2,
+                representative3,
+            } => {
+                if representative1 == representative2
+                    || representative1 == representative3
+                    || representative2 == representative3
+                {
+                    return Err(FactoryError::InvalidInput(
+                        "Representatives must all be different".to_string(),
+                    ));
+                }
+                Ok(())
+            }
+            GroupType::Press { .. } | GroupType::LabProject { .. } => Ok(()),
+        }
+    }
 }
 
 pub struct Group {
@@ -58,6 +108,7 @@ impl Group {
         if name.trim().is_empty() {
             return Err(FactoryError::InvalidInput("Name is empty".to_string()));
         }
+        r#type.validate()?;
 
         Ok(Self {
             id,
@@ -144,6 +195,10 @@ impl Group {
                 self.id
             )));
         }
+
+        r#type
+            .validate()
+            .map_err(|e| UpdateRolesError::InvalidInput(e.to_string()))?;
 
         self.r#type = r#type;
         self.updated_at = clock.now();

--- a/apps/backend/src/domain/membership.rs
+++ b/apps/backend/src/domain/membership.rs
@@ -46,8 +46,15 @@ impl Membership {
                     Membership::new(group_id, *representative3, clock),
                 ]
             }
-            GroupType::LabProject { representative } => {
-                vec![Membership::new(group_id, *representative, clock)]
+            GroupType::LabProject { representative, operator} => {
+                if operator == representative {
+                    vec![Membership::new(group_id, *operator, clock)]
+                } else {
+                    vec![
+                        Membership::new(group_id, *representative, clock),
+                        Membership::new(group_id, *operator, clock),
+                    ]
+                }
             }
             GroupType::StageProject {
                 representative1,

--- a/apps/backend/tests/application/common.rs
+++ b/apps/backend/tests/application/common.rs
@@ -54,6 +54,7 @@ pub fn parse_group_type(s: &str) -> GroupType {
         },
         "labo" => GroupType::LabProject {
             representative: uid(),
+            operator: uid(),
         },
         s => panic!("unknown group_type: {s}"),
     }

--- a/apps/backend/tests/domain/actor_ctx.rs
+++ b/apps/backend/tests/domain/actor_ctx.rs
@@ -52,6 +52,7 @@ fn parse_actor(s: &str) -> ActorContext {
         "user_labo" => {
             user_ctx(GroupType::LabProject {
                 representative: u(),
+                operator: u(),
             })
             .1
         }

--- a/apps/backend/tests/domain/group.rs
+++ b/apps/backend/tests/domain/group.rs
@@ -37,6 +37,7 @@ fn parse_group_type(s: &str) -> GroupType {
         },
         "lab_project" => GroupType::LabProject {
             representative: u(),
+            operator: u(),
         },
         "stage_project" => GroupType::StageProject {
             representative1: u(),

--- a/apps/backend/tests/domain/membership.rs
+++ b/apps/backend/tests/domain/membership.rs
@@ -35,6 +35,7 @@ pub fn test_from_group_type(_path: &Path, contents: String) -> datatest_stable::
         },
         "lab_project" => GroupType::LabProject {
             representative: u(),
+            operator: u(),
         },
         "stage_project" => GroupType::StageProject {
             representative1: u(),

--- a/apps/backend/tests/domain/target_specifier.rs
+++ b/apps/backend/tests/domain/target_specifier.rs
@@ -85,6 +85,7 @@ fn parse_group_type(s: &str) -> GroupType {
         },
         "labo" => GroupType::LabProject {
             representative: u(),
+            operator: u(),
         },
         _ => GroupType::Press {
             representative: u(),

--- a/apps/backend/tests/fixtures/domain/membership/from_group_type/lab_project.json
+++ b/apps/backend/tests/fixtures/domain/membership/from_group_type/lab_project.json
@@ -1,4 +1,4 @@
 {
   "group_type": "lab_project",
-  "expected_count": 1
+  "expected_count": 2
 }


### PR DESCRIPTION
> [!NOTE]
> https://discord.com/channels/528826586368049156/548068414854529055/1488472220853338182 を参照

## Summary

- `LabProject` に `operator`（企画実施担当者）フィールドを追加
- `GroupType::validate()` を実装し，`GeneralProject` / `BoothProject` / `StageProject` の第一〜第三責任者が全員異なることを強制（`register` および `update_roles` 両方で検証）
- `LabProject` は `representative` と `operator` の兼任を許可（同一 UserId 可）
- `Membership::from_group_type` の `LabProject` 対応を更新（兼任時は Membership 1件，別人時は2件）

## Test plan

- [ ] `GroupType` バリデーション: 3責任者型で重複があると `FactoryError::InvalidInput` が返ることを確認
- [ ] `GroupType` バリデーション: 3責任者型で全員異なる場合は成功することを確認
- [ ] `LabProject` 兼任: 同一 UserId で `register` が成功することを確認
- [ ] `LabProject` 兼任: `Membership::from_group_type` が1件返すことを確認
- [ ] `update_roles` でも重複バリデーションが機能することを確認
- [ ] `cargo test domain::group` / `domain::membership` が全て通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)