### PR TITLE
feat: allow backend config path override

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,9 @@ We welcome contributions to this repository!
     ./init-keys.sh
     ```
 4. **コンフィグを正しい位置に配置**
+    `npx nx dev backend` または `npx nx dev` で開発環境を起動する場合は，`apps/backend/debug/default-config.toml` が自動で読み込まれます．
+
+    手動で backend を起動する場合は，以下のようにコンフィグを配置してください．
     ```shell
     cd apps/backend/debug
     cp default-config.toml <配置先>
@@ -30,6 +33,11 @@ We welcome contributions to this repository!
    - macOS: `~/Library/Application Support/rs.koudaisai-portal/`
    - Linux: `~/.config/koudaisai-portal/`
    - Windows: `C:\Users\<ユーザー名>\AppData\Roaming\rs.koudaisai-portal\`
+
+   または，環境変数 `KOUDAISAI_PORTAL_CONFIG_PATH` にコンフィグファイルのパスを指定できます．
+   ```shell
+   export KOUDAISAI_PORTAL_CONFIG_PATH=/path/to/config.toml
+   ```
     
 5. **開発環境用データベース・Keycloakを起動**
     ```shell

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,5 +1,16 @@
 # dbの起動
 `$ docker compose up -d`
+
+# config
+デフォルトでは OS ごとの標準設定ディレクトリから `koudaisai-portal` の設定を読み込みます．
+任意の場所にある config を使う場合は，環境変数 `KOUDAISAI_PORTAL_CONFIG_PATH` に TOML ファイルのパスを指定してください．
+
+```shell
+export KOUDAISAI_PORTAL_CONFIG_PATH=/path/to/config.toml
+```
+
+`nx dev backend` では `apps/backend/debug/default-config.toml` を自動で読み込みます．
+
 # migration
 > [!IMPORTANT]
 > `$ nx docker-up backend`で開発環境を起動する必要があります．

--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -42,7 +42,10 @@
       "executor": "nx:run-commands",
       "options": {
         "command": "cargo watch -x run",
-        "cwd": "apps/backend"
+        "cwd": "apps/backend",
+        "env": {
+          "KOUDAISAI_PORTAL_CONFIG_PATH": "./debug/default-config.toml"
+        }
       },
       "dependsOn": [
         "docker-up"

--- a/apps/backend/src/config.rs
+++ b/apps/backend/src/config.rs
@@ -3,11 +3,16 @@ use confy::ConfyError;
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use rand::distr::{Alphanumeric, SampleString};
 use serde::{Deserialize, Serialize};
-use std::fs;
+use std::{env, fs, path::PathBuf};
 use tracing_core::LevelFilter;
 
+pub const CONFIG_PATH_ENV: &str = "KOUDAISAI_PORTAL_CONFIG_PATH";
+
 pub fn init_config() -> Result<Config, ConfyError> {
-    confy::load("koudaisai-portal", None)
+    match env::var_os(CONFIG_PATH_ENV).filter(|path| !path.is_empty()) {
+        Some(path) => confy::load_path(PathBuf::from(path)),
+        None => confy::load("koudaisai-portal", None),
+    }
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]


### PR DESCRIPTION
## Summary
- allow the backend to read config from `KOUDAISAI_PORTAL_CONFIG_PATH`
- keep the existing `confy` default location when the variable is unset or empty
- configure `nx dev backend` to read `apps/backend/debug/default-config.toml`
- document the environment variable and Nx dev behavior

## Validation
- `cargo fmt --check`
- `cargo check` completed successfully before commit; it reported existing warnings but no errors
- `apps/backend/project.json` parsed successfully with Node

## Notes
- `npx nx show project backend --json` could not be used locally because Nx plugin workers failed to start in this environment
