### PR TITLE
Add lint target to backend Nx project to run cargo clippy

### DIFF
--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -50,6 +50,13 @@
       "dependsOn": [
         "docker-up"
       ]
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cargo clippy --all-targets --all-features -- -A warnings",
+        "cwd": "apps/backend"
+      }
     }
   }
 }

--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -54,7 +54,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cargo clippy --all-targets --all-features -- -A warnings",
+        "command": "cargo clippy --all-targets --all-features -- -D warnings",
         "cwd": "apps/backend"
       }
     }


### PR DESCRIPTION
### Motivation
- Add a reusable lint step for the Rust backend so repository tooling can run `cargo clippy` via Nx.

### Description
- Add a `lint` target to `apps/backend/project.json` using the `nx:run-commands` executor that runs `cargo clippy --all-targets --all-features -- -A warnings` with `cwd` set to `apps/backend`.

### Testing
- No automated tests were run as part of this change; CI will exercise the new `lint` target when workflows run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11c521a1e8832190e7fd46a05b0f62)