### PR TITLE
ci: replace backend workflows with nx affected targets

### DIFF
--- a/.github/workflows/affected-check.yml
+++ b/.github/workflows/affected-check.yml
@@ -1,4 +1,4 @@
-name: Backend Test
+name: Affected Check
 
 on:
   pull_request:
@@ -7,11 +7,13 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: nx test backend
+  check:
+    name: nx affected -t check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -25,5 +27,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run backend tests
-        run: npx nx test backend
+      - name: Set Nx SHAs
+        uses: nrwl/nx-set-shas@v4
+
+      - name: Run affected check
+        run: npx nx affected -t check

--- a/.github/workflows/affected-format-check.yml
+++ b/.github/workflows/affected-format-check.yml
@@ -1,4 +1,4 @@
-name: Backend Format Check
+name: Affected Format Check
 
 on:
   pull_request:
@@ -8,10 +8,12 @@ permissions:
 
 jobs:
   format-check:
-    name: nx format-check backend
+    name: nx affected -t format:check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -25,5 +27,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run backend format check
-        run: npx nx format-check backend
+      - name: Set Nx SHAs
+        uses: nrwl/nx-set-shas@v4
+
+      - name: Run affected format check
+        run: npx nx affected -t format:check

--- a/.github/workflows/affected-lint.yml
+++ b/.github/workflows/affected-lint.yml
@@ -1,4 +1,4 @@
-name: Backend Check
+name: Affected Lint
 
 on:
   pull_request:
@@ -7,11 +7,13 @@ permissions:
   contents: read
 
 jobs:
-  check:
-    name: nx check backend
+  lint:
+    name: nx affected -t lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -25,5 +27,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run backend check
-        run: npx nx check backend
+      - name: Set Nx SHAs
+        uses: nrwl/nx-set-shas@v4
+
+      - name: Run affected lint
+        run: npx nx affected -t lint

--- a/.github/workflows/affected-test.yml
+++ b/.github/workflows/affected-test.yml
@@ -1,0 +1,34 @@
+name: Affected Test
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: nx affected -t test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Setup Rust
+        run: rustup default stable
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set Nx SHAs
+        uses: nrwl/nx-set-shas@v4
+
+      - name: Run affected test
+        run: npx nx affected -t test


### PR DESCRIPTION
### Motivation
- Reduce wasted CI runs by switching backend-specific workflows to Nx's affected mode so only projects changed by a PR are exercised.
- Split check/lint/format/test into independent workflows to make CI responsibilities clearer and easier to reason about.
- Unify environment setup across these workflows (Node.js, Rust, `npm ci`, and Nx SHAs) for consistency.

### Description
- Removed the old `backend-*.yml` workflows and added four new workflows: `affected-check.yml`, `affected-lint.yml`, `affected-format-check.yml`, and `affected-test.yml` that run on `pull_request`.
- Each workflow uses `actions/checkout@v4` with `fetch-depth: 0`, `actions/setup-node@v4` (Node.js 24), `rustup default stable`, and `npm ci` before running `nrwl/nx-set-shas@v4` and the appropriate `npx nx affected -t <target>` command.
- The targets executed by the workflows are `check`, `lint`, `format:check`, and `test`, respectively.
- Workflows are committed and the change is recorded in the repository history.

### Testing
- No automated CI jobs were executed in this environment; the new workflows are configured to run on `pull_request` and will perform `npx nx affected -t check`, `npx nx affected -t lint`, `npx nx affected -t format:check`, and `npx nx affected -t test` when the PR triggers GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11cd3316f483219434df234c014005)