### PR TITLE
chore: run backend `cargo fmt` from root format scripts

### DIFF
--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -57,6 +57,13 @@
         "command": "cargo clippy --all-targets --all-features -- -D warnings",
         "cwd": "apps/backend"
       }
+    },
+    "format": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cargo fmt --all",
+        "cwd": "apps/backend"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18542,6 +18542,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "format": "prettier . --write",
-    "format:check": "prettier . --check"
+    "format": "prettier . --write && npx nx run backend:format",
+    "format:check": "prettier . --check && npx nx run backend:format-check"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
### Motivation
- The repository uses Prettier for JS/TS formatting but the Rust backend should be formatted with `cargo fmt` so running the root `format` should also apply Rust formatting for `apps/backend`.

### Description
- Added a `format` target to `apps/backend/project.json` that runs `cargo fmt --all` for the backend.
- Updated root `package.json` scripts so `format` runs `prettier . --write && npx nx run backend:format` and `format:check` runs `prettier . --check && npx nx run backend:format-check`.

### Testing
- Ran `npx nx run backend:format-check` which executed `cargo fmt --all -- --check` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11cdc74b548321ad88a2d9fa67eb60)