### PR TITLE
[codex] backend format check target and lockfile update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ sea-orm-cli generate entity  # DB スキーマから SeaORM エンティティ�
 ## アーキテクチャ
 
 ### モノレポ構成
+
 - `apps/portal/` - 参加団体向けポータル（フロントエンド）
 - `apps/admin/` - 管理画面（フロントエンド）
 - `apps/join/` - Join フロントエンド
@@ -48,6 +49,7 @@ sea-orm-cli generate entity  # DB スキーマから SeaORM エンティティ�
 - `docs/` - OpenAPI 仕様とドキュメント
 
 ### バックエンドレイヤー（`apps/backend/src/`）
+
 1. `routes/` - HTTP エンドポイント
 2. `middlewares.rs` - 認証、ロギング
 3. `entities/` - ビジネスロジック
@@ -56,10 +58,12 @@ sea-orm-cli generate entity  # DB スキーマから SeaORM エンティティ�
 6. `util/` - JWT、OIDC、ハッシュ化
 
 ### 認証
+
 - **JIZI（管理者）**: Keycloak OIDC
 - **Group（参加団体）**: 初回ログイン時に有効化するカスタム JWT
 
 ### 外部サービス
+
 - PostgreSQL（データ）、S3/Wasabi（ファイル）、Keycloak（認証）
 - Discord（通知）、SendGrid/SES（メール）
 - 外部 API: api2025.jizi.jp（企画情報同期）
@@ -76,6 +80,7 @@ sea-orm-cli generate entity  # DB スキーマから SeaORM エンティティ�
 このリポジトリでは Nix flakes を使って開発に必要なツールを揃えます（主なツール: Rust、Node.js、cargo-watch、git）。
 
 ### 事前に必要なもの
+
 - Nix
 - direnv
 - Docker daemon を起動できる環境（Docker Desktop など）
@@ -83,6 +88,7 @@ sea-orm-cli generate entity  # DB スキーマから SeaORM エンティティ�
 > Docker と Docker Compose は開発用 DB・Keycloak の起動に使用します。`npx nx docker-up backend` の実行前に Docker daemon を起動してください。
 
 ### セットアップ手順
+
 1. `direnv allow` を実行して Nix の開発環境を有効化
 2. リポジトリルートで `npm ci` を実行
 3. JWT キーを生成: `cd apps/backend/debug && ./init-keys.sh`
@@ -98,6 +104,7 @@ sea-orm-cli generate entity  # DB スキーマから SeaORM エンティティ�
 6. 開発環境を起動: `npx nx dev`
 
 利用 URL:
+
 - portal: `http://portal.koudaisai.localhost`
 - admin: `http://admin.koudaisai.localhost`
 - join: `http://join.koudaisai.localhost`
@@ -110,4 +117,5 @@ sea-orm-cli generate entity  # DB スキーマから SeaORM エンティティ�
 ```
 <prefix>/#<issue>-<short-title>
 ```
+
 プレフィックス: feature, fix, hotfix, refactor, chore, test

--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -17,7 +17,7 @@
         "cwd": "apps/backend"
       }
     },
-    "format-check": {
+    "format:check": {
       "executor": "nx:run-commands",
       "options": {
         "command": "cargo fmt --all -- --check",
@@ -47,9 +47,7 @@
           "KOUDAISAI_PORTAL_CONFIG_PATH": "./debug/default-config.toml"
         }
       },
-      "dependsOn": [
-        "docker-up"
-      ]
+      "dependsOn": ["docker-up"]
     },
     "lint": {
       "executor": "nx:run-commands",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18542,6 +18542,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",


### PR DESCRIPTION
## Summary

- Rename the backend Nx format check target from `format-check` to `format:check`.
- Keep the backend `dev` target dependency formatting consistent.
- Update `package-lock.json` with the Prettier entry required by the current dependency graph.

## Validation

- `cargo fmt --all -- --check` from `apps/backend`

## Notes

- `npx nx format:check backend` could not be used locally because Nx plugin workers failed to start in this environment, so the underlying backend format command was run directly.