### PR TITLE
ci: disable Nx Cloud and persist Nx local cache in GitHub Actions

### DIFF
--- a/.github/workflows/affected-check.yml
+++ b/.github/workflows/affected-check.yml
@@ -30,5 +30,13 @@ jobs:
       - name: Set Nx SHAs
         uses: nrwl/nx-set-shas@v4
 
+      - name: Cache Nx local cache
+        uses: actions/cache@v4
+        with:
+          path: .nx/cache
+          key: ${{ runner.os }}-nx-${{ hashFiles('**/package-lock.json') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-nx-${{ hashFiles('**/package-lock.json') }}-
+
       - name: Run affected check
         run: npx nx affected -t check

--- a/.github/workflows/affected-format-check.yml
+++ b/.github/workflows/affected-format-check.yml
@@ -30,5 +30,13 @@ jobs:
       - name: Set Nx SHAs
         uses: nrwl/nx-set-shas@v4
 
+      - name: Cache Nx local cache
+        uses: actions/cache@v4
+        with:
+          path: .nx/cache
+          key: ${{ runner.os }}-nx-${{ hashFiles('**/package-lock.json') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-nx-${{ hashFiles('**/package-lock.json') }}-
+
       - name: Run affected format check
         run: npx nx affected -t format:check

--- a/.github/workflows/affected-lint.yml
+++ b/.github/workflows/affected-lint.yml
@@ -30,5 +30,13 @@ jobs:
       - name: Set Nx SHAs
         uses: nrwl/nx-set-shas@v4
 
+      - name: Cache Nx local cache
+        uses: actions/cache@v4
+        with:
+          path: .nx/cache
+          key: ${{ runner.os }}-nx-${{ hashFiles('**/package-lock.json') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-nx-${{ hashFiles('**/package-lock.json') }}-
+
       - name: Run affected lint
         run: npx nx affected -t lint

--- a/.github/workflows/affected-test.yml
+++ b/.github/workflows/affected-test.yml
@@ -30,5 +30,13 @@ jobs:
       - name: Set Nx SHAs
         uses: nrwl/nx-set-shas@v4
 
+      - name: Cache Nx local cache
+        uses: actions/cache@v4
+        with:
+          path: .nx/cache
+          key: ${{ runner.os }}-nx-${{ hashFiles('**/package-lock.json') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-nx-${{ hashFiles('**/package-lock.json') }}-
+
       - name: Run affected test
         run: npx nx affected -t test

--- a/nx.json
+++ b/nx.json
@@ -12,7 +12,6 @@
     ],
     "sharedGlobals": []
   },
-  "nxCloudId": "67eee21417ad73371d831d9e",
   "plugins": [
     {
       "plugin": "@nx/js/typescript",


### PR DESCRIPTION
### Motivation

- Nx Cloud was enabled via `nxCloudId` in `nx.json`, but the CI should not depend on Nx Cloud and should instead persist the local Nx cache in GitHub Actions.

### Description

- Removed the `nxCloudId` entry from `nx.json` to disable Nx Cloud usage and enforce local cache behavior.
- Updated four affected workflows (`.github/workflows/affected-check.yml`, `affected-format-check.yml`, `affected-lint.yml`, `affected-test.yml`) to add a `actions/cache@v4` step that stores and restores `.nx/cache`.
- Cache keys are configured as `runner.os + hash of package-lock.json + github.sha` with a `restore-keys` fallback to reuse prior caches for the same lockfile lineage.

### Testing

- No automated tests were executed as part of this PR; changes are limited to CI configuration and the repository manifest, and should be validated on the next GitHub Actions run where the updated workflows will exercise the new caching behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11d3ec776c8321a93183921c6fe84b)