### PR TITLE
[codex] frontend deployment tasks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,6 @@
 /.nx/cache
 /.nx/workspace-data
 **/target
+/libs/shared-types/src/api_v2.d.ts
+/libs/shared-types/src/auth_v1.d.ts
+/libs/shared-types/src/plans_info_api_v1.d.ts

--- a/apps/admin/project.json
+++ b/apps/admin/project.json
@@ -11,14 +11,31 @@
     "@koudaisai/shared-utils"
   ],
   "targets": {
-    "build": {
+    "build:development": {
       "executor": "nx:run-commands",
       "outputs": ["{projectRoot}/dist"],
       "options": {
-        "command": "astro build",
+        "command": "astro build --mode development",
         "cwd": "apps/admin"
       },
       "dependsOn": ["^build"]
+    },
+    "build:production": {
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/dist"],
+      "options": {
+        "command": "astro build --mode production",
+        "cwd": "apps/admin"
+      },
+      "dependsOn": ["^build"]
+    },
+    "deploy:production": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx wrangler deploy",
+        "cwd": "apps/admin"
+      },
+      "dependsOn": ["build:production"]
     },
     "dev": {
       "executor": "nx:run-commands",

--- a/apps/admin/wrangler.toml
+++ b/apps/admin/wrangler.toml
@@ -1,4 +1,4 @@
-name = "koudaisai-portal/admin"
+name = "koudaisai-portal-admin"
 compatibility_date = "2025-09-05"
 preview_urls = true
 

--- a/apps/admin/wrangler.toml
+++ b/apps/admin/wrangler.toml
@@ -1,4 +1,4 @@
-name = "koudaisai-portal/join"
+name = "koudaisai-portal/admin"
 compatibility_date = "2025-09-05"
 preview_urls = true
 

--- a/apps/join/project.json
+++ b/apps/join/project.json
@@ -7,14 +7,31 @@
     "@koudaisai/shared-api"
   ],
   "targets": {
-    "build": {
+    "build:development": {
       "executor": "nx:run-commands",
       "outputs": ["{projectRoot}/dist"],
       "options": {
-        "command": "astro build",
+        "command": "astro build --mode development",
         "cwd": "apps/join"
       },
       "dependsOn": ["^build"]
+    },
+    "build:production": {
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/dist"],
+      "options": {
+        "command": "astro build --mode production",
+        "cwd": "apps/join"
+      },
+      "dependsOn": ["^build"]
+    },
+    "deploy:production": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx wrangler deploy",
+        "cwd": "apps/join"
+      },
+      "dependsOn": ["build:production"]
     },
     "dev": {
       "executor": "nx:run-commands",

--- a/apps/join/wrangler.toml
+++ b/apps/join/wrangler.toml
@@ -1,4 +1,4 @@
-name = "koudaisai-portal/join"
+name = "koudaisai-portal-join"
 compatibility_date = "2025-09-05"
 preview_urls = true
 

--- a/apps/portal/project.json
+++ b/apps/portal/project.json
@@ -12,14 +12,31 @@
     "@koudaisai/shared-utils"
   ],
   "targets": {
-    "build": {
+    "build:development": {
       "executor": "nx:run-commands",
       "outputs": ["{projectRoot}/dist"],
       "options": {
-        "command": "astro build",
+        "command": "astro build --mode development",
         "cwd": "apps/portal"
       },
       "dependsOn": ["^build"]
+    },
+    "build:production": {
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/dist"],
+      "options": {
+        "command": "astro build --mode production",
+        "cwd": "apps/portal"
+      },
+      "dependsOn": ["^build"]
+    },
+    "deploy:production": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx wrangler deploy",
+        "cwd": "apps/portal"
+      },
+      "dependsOn": ["build:production"]
     },
     "dev": {
       "executor": "nx:run-commands",

--- a/apps/portal/wrangler.toml
+++ b/apps/portal/wrangler.toml
@@ -1,4 +1,4 @@
-name = "koudaisai-portal/portal"
+name = "koudaisai-portal-portal"
 compatibility_date = "2025-09-05"
 preview_urls = true
 

--- a/apps/portal/wrangler.toml
+++ b/apps/portal/wrangler.toml
@@ -1,4 +1,4 @@
-name = "koudaisai-portal/join"
+name = "koudaisai-portal/portal"
 compatibility_date = "2025-09-05"
 preview_urls = true
 
@@ -9,5 +9,5 @@ directory = "dist"
 enabled = true
 
 [[routes]]
-pattern = "join.koudaisai.jp"
+pattern = "portal.koudaisai.jp"
 custom_domain = true

--- a/libs/shared-types/src/api_v2.d.ts
+++ b/libs/shared-types/src/api_v2.d.ts
@@ -4,3030 +4,2999 @@
  */
 
 export interface paths {
-  '/groups': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** すべての団体を取得 */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['GroupRead'][];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/groups/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 団体を取得
-     * @description ### authの違いによる挙動の違い
-     *     - **exhibitor_bearerの場合**: 自分が属する団体のみ取得可能
-     *     - **admin_oidcの場合**: 存在する全ての団体を取得可能
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 団体ID */
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['GroupRead'];
-          };
-        };
-        /** @description 団体が存在しない */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    /** 団体を追加 */
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 団体のID */
-          id: components['schemas']['GroupId'];
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['GroupCreate'];
-        };
-      };
-      responses: {
-        /** @description 団体が追加された */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['PutGroupResponse'];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 団体またはユーザーがすでに存在する */
-        409: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    post?: never;
-    /** 団体を削除 */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 団体ID */
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 団体が削除された */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 団体が存在しない */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    /**
-     * 団体を編集
-     * @description ### authの違いによる挙動の違い
-     *     - **exhibitor_bearerの場合**: 自分が属する団体のみ編集可能
-     *     - **admin_oidcの場合**: 存在する全ての団体を編集可能
-     */
-    patch: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 団体ID */
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['GroupUpdate'];
-        };
-      };
-      responses: {
-        /** @description 団体が編集された */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 団体が存在しない */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    trace?: never;
-  };
-  '/groups/{id}/plan-details': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 企画の詳細情報を取得
-     * @description 自分が属する団体の企画のみ取得可能。取材団体等の企画と紐付けされていない団体は404が返されます。
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 団体のID */
-          id: components['schemas']['GroupId'];
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['PlanDetailsRead'];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 企画が存在しない */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    /**
-     * 企画詳細情報を上書き
-     * @description 自分が属する団体のみ上書き可能
-     */
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 団体のID */
-          id: components['schemas']['GroupId'];
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['PlanDetailsCreate'];
-        };
-      };
-      responses: {
-        /** @description 企画情報が正常に編集された */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 企画が存在しない */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forms': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * アクセス可能なフォームをすべて取得
-     * @description ### authの違いによる挙動の違い
-     *     - **exhibitor_bearerの場合**: targetに基づいてアクセス可能なフォームを取得
-     *     - **admin_oidcの場合**: 存在するフォームを全て取得
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['FormRead'][];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    /** フォームを新規作成 */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['FormCreate'];
-        };
-      };
-      responses: {
-        /** @description NoContent */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forms/{form_id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * フォームを取得
-     * @description ### authの違いによる挙動の違い
-     *     - **exhibitor_bearerの場合**: targetに基づいてアクセス可能なフォームな場合取得
-     *     - **admin_oidcの場合**: 存在するフォームを全て取得
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description フォームID */
-          form_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['FormRead'];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    /** フォームを削除 */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description フォームID */
-          form_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description No Content */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description フォームが存在しない */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    /** フォームを更新 */
-    patch: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description フォームID */
-          form_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['FormUpdate'];
-        };
-      };
-      responses: {
-        /** @description No Content */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    trace?: never;
-  };
-  '/documents': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * アクセス可能な資料をすべて取得
-     * @description ### authの違いによる挙動の違い
-     *     - **exhibitor_bearerの場合**: 自分が属する参加団体の属性に基づいてアクセス可能な資料を取得
-     *     - **admin_oidcの場合**: 存在する資料を全て取得
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ReadDocument'][];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    /** 資料を新規作成 */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['CreateDocument'];
-        };
-      };
-      responses: {
-        /** @description Changed */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ReadDocument'];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/documents/by-category': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 資料カテゴリと資料のマップを取得
-     * @description ### authの違いによる挙動の違い
-     *     - **exhibitor_bearerの場合**: 自分が属する参加団体の属性に基づいてアクセス可能な資料な場合取得
-     *     - **admin_oidcの場合**: 存在する資料を全て取得可能
-     */
-    get: {
-      parameters: {
-        query?: {
-          /**
-           * @description 空のカテゴリも含めるかどうか。デフォルトは`false`。
-           *     `true`の場合、資料が存在しないカテゴリも含まれる。
-           */
-          include_empty_categories?: boolean;
-        };
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              category: components['schemas']['ReadDocumentCategory'] | null;
-              documents: components['schemas']['ReadDocument'][];
-            }[];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/documents/{document_id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 資料を取得
-     * @description ### authの違いによる挙動の違い
-     *     - **exhibitor_bearerの場合**: 自分が属する参加団体の属性に基づいてアクセス可能な資料な場合取得
-     *     - **admin_oidcの場合**: 存在する資料を全て取得可能
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 資料のID */
-          document_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ReadDocument'];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    /** 資料を削除 */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description フォームID */
-          document_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 削除成功 */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description フォームが存在しない */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    /** 資料を更新 */
-    patch: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 資料のID */
-          document_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['UpdateDocument'];
-        };
-      };
-      responses: {
-        /** @description Changed */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ReadDocument'][];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    trace?: never;
-  };
-  '/document-categories': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** 資料カテゴリをすべて取得 */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ReadDocumentCategory'][];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    /** 資料カテゴリを新規作成 */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['CreateDocumentCategory'];
-        };
-      };
-      responses: {
-        /** @description Changed */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ReadDocumentCategory'];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/document-categories/{category_id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** 資料カテゴリを取得 */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 資料カテゴリのID */
-          category_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ReadDocumentCategory'];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    /** 資料カテゴリを削除 */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description カテゴリID */
-          category_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 削除成功 */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description フォームが存在しない */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    /** 資料カテゴリを更新 */
-    patch: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 資料カテゴリのID */
-          category_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['UpdateDocumentCategory'];
-        };
-      };
-      responses: {
-        /** @description Changed */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ReadDocumentCategory'][];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    trace?: never;
-  };
-  '/files/upload': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** ファイルのアップロードurlを取得 */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            file_name: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Changed */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              presigned_url: string;
-              key: string;
+    "/groups": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** すべての団体を取得 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
             };
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/files/download': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** ファイルのダウンロードurlを取得 */
-    get: {
-      parameters: {
-        query: {
-          key: string;
-          file_name: string;
-          /** @description リダイレクトするかどうか．デフォルト値は`false` */
-          redirect?: boolean;
-        };
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Changed */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              presigned_url?: string;
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["GroupRead"][];
+                    };
+                };
             };
-          };
         };
-        /** @description redirect=trueの場合に返される．リソースへのリダイレクト */
-        302: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/users': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** ユーザーを全て取得 */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['UserRead'][];
-          };
+    "/groups/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/users/{user_id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * ユーザー情報を取得
-     * @description ### authの違いによる挙動の違い
-     *     - **exhibitor_bearerの場合**: ユーザーが自身の所属する参加団体に所属している場合のみ取得可能
-     *     - **admin_oidcの場合**: いかなるユーザー情報も取得可能
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description ユーザーID */
-          user_id: components['schemas']['UserId'];
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['UserRead'];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /** ユーザー情報を更新 */
-    patch: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description ユーザーID */
-          user_id: components['schemas']['UserId'];
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['UserUpdate'];
-        };
-      };
-      responses: {
-        /** @description 更新成功 */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    trace?: never;
-  };
-  '/users/{user_id}/notifications': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** そのユーザー向けの通知と既読状況を取得 */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description ユーザーID */
-          user_id: components['schemas']['UserId'];
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              notification: components['schemas']['NotificationRead'];
-              /**
-               * @description その通知が既読かどうかを示すフラグ
-               *     trueの場合、通知は既読であることを示す
-               */
-              is_read: boolean;
-            }[];
-          };
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/users/{user_id}/approval_requests': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** 承認申請をすべて取得 */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description ユーザーのID */
-          user_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ReadApprovalRequest'][];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description サーバーエラー */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    /** 承認申請を新規作成 */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description ユーザーのID */
-          user_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['CreateApprovalRequest'];
-        };
-      };
-      responses: {
-        /** @description No Content */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description サーバーエラー */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/users/{user_id}/approval_requests/{request_id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** 承認申請を取得 */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description ユーザーのID */
-          user_id: string;
-          /** @description 承認申請のID */
-          request_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ReadApprovalRequest'];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 承認申請が存在しないか、アクセス権限がない */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description サーバーエラー */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/users/{user_id}/approval_requests/{request_id}/close': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** 承認申請を取り下げる */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description ユーザーのID */
-          user_id: string;
-          /** @description 承認申請のID */
-          request_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description No Content */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description サーバーエラー */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/users/{user_id}/m_address': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** mアドレスを変更する */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description ユーザーのID */
-          user_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            /**
-             * Format: email
-             * @description 新しいmアドレス
-             */
-            m_address: string;
-          };
-        };
-      };
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @description 新規mアドレスを有効化するためのアクティベーショントークン */
-              activation_token?: string;
+        /**
+         * 団体を取得
+         * @description ### authの違いによる挙動の違い
+         *     - **exhibitor_bearerの場合**: 自分が属する団体のみ取得可能
+         *     - **admin_oidcの場合**: 存在する全ての団体を取得可能
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 団体ID */
+                    id: string;
+                };
+                cookie?: never;
             };
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description サーバーエラー */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/notifications': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** 全ての通知を取得 */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['NotificationRead'][];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    /** 通知を新規作成 */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['NotificationCreate'];
-        };
-      };
-      responses: {
-        /** @description Created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/notifications/{notification_id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 通知を取得
-     * @description ### authの違いによる挙動の違い
-     *     - **exhibitor_bearerの場合**: 自分が通知対象である場合通知を取得可能
-     *     - **admin_oidcの場合**: 存在する通知を全て取得可能
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 通知id */
-          notification_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['NotificationRead'];
-          };
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    /** 通知を削除 */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 通知ID */
-          notification_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description No Content */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description フォームが存在しない */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    /** 通知を更新 */
-    patch: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 通知ID */
-          notification_id: string;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['NotificationUpdate'];
-        };
-      };
-      responses: {
-        /** @description No Content */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    trace?: never;
-  };
-  '/util/meta': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** ページのメタデータを取得 */
-    get: {
-      parameters: {
-        query: {
-          /** @description フォームID */
-          url: string;
-        };
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @description The title of the page. */
-              title: string | null;
-              /** @description The description of the page. */
-              description: string | null;
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["GroupRead"];
+                    };
+                };
+                /** @description 団体が存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
             };
-          };
         };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        /** 団体を追加 */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 団体のID */
+                    id: components["schemas"]["GroupId"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["GroupCreate"];
+                };
+            };
+            responses: {
+                /** @description 団体が追加された */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PutGroupResponse"];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 団体またはユーザーがすでに存在する */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        post?: never;
+        /** 団体を削除 */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 団体ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 団体が削除された */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 団体が存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-      };
+        options?: never;
+        head?: never;
+        /**
+         * 団体を編集
+         * @description ### authの違いによる挙動の違い
+         *     - **exhibitor_bearerの場合**: 自分が属する団体のみ編集可能
+         *     - **admin_oidcの場合**: 存在する全ての団体を編集可能
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 団体ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["GroupUpdate"];
+                };
+            };
+            responses: {
+                /** @description 団体が編集された */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 団体が存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        trace?: never;
     };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/approval-requests': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/groups/{id}/plan-details": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 企画の詳細情報を取得
+         * @description 自分が属する団体の企画のみ取得可能。取材団体等の企画と紐付けされていない団体は404が返されます。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 団体のID */
+                    id: components["schemas"]["GroupId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PlanDetailsRead"];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 企画が存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        /**
+         * 企画詳細情報を上書き
+         * @description 自分が属する団体のみ上書き可能
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 団体のID */
+                    id: components["schemas"]["GroupId"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["PlanDetailsCreate"];
+                };
+            };
+            responses: {
+                /** @description 企画情報が正常に編集された */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 企画が存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** 承認申請をすべて取得 */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ReadApprovalRequest'][];
-          };
+    "/forms": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        /**
+         * アクセス可能なフォームをすべて取得
+         * @description ### authの違いによる挙動の違い
+         *     - **exhibitor_bearerの場合**: targetに基づいてアクセス可能なフォームを取得
+         *     - **admin_oidcの場合**: 存在するフォームを全て取得
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["FormRead"][];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        put?: never;
+        /** フォームを新規作成 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["FormCreate"];
+                };
+            };
+            responses: {
+                /** @description NoContent */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-        /** @description サーバーエラー */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/approval-requests/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/forms/{form_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * フォームを取得
+         * @description ### authの違いによる挙動の違い
+         *     - **exhibitor_bearerの場合**: targetに基づいてアクセス可能なフォームな場合取得
+         *     - **admin_oidcの場合**: 存在するフォームを全て取得
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description フォームID */
+                    form_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["FormRead"];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** フォームを削除 */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description フォームID */
+                    form_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description フォームが存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** フォームを更新 */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description フォームID */
+                    form_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["FormUpdate"];
+                };
+            };
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        trace?: never;
     };
-    /** 承認申請を取得 */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 承認申請のID */
-          id: string;
+    "/documents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ReadApprovalRequest'];
-          };
+        /**
+         * アクセス可能な資料をすべて取得
+         * @description ### authの違いによる挙動の違い
+         *     - **exhibitor_bearerの場合**: 自分が属する参加団体の属性に基づいてアクセス可能な資料を取得
+         *     - **admin_oidcの場合**: 存在する資料を全て取得
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReadDocument"][];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        put?: never;
+        /** 資料を新規作成 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreateDocument"];
+                };
+            };
+            responses: {
+                /** @description Changed */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReadDocument"];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description サーバーエラー */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    post?: never;
-    /** 承認申請を削除 */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 承認申請のID */
-          id: string;
+    "/documents/by-category": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 削除成功 */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        /**
+         * 資料カテゴリと資料のマップを取得
+         * @description ### authの違いによる挙動の違い
+         *     - **exhibitor_bearerの場合**: 自分が属する参加団体の属性に基づいてアクセス可能な資料な場合取得
+         *     - **admin_oidcの場合**: 存在する資料を全て取得可能
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /**
+                     * @description 空のカテゴリも含めるかどうか。デフォルトは`false`。
+                     *     `true`の場合、資料が存在しないカテゴリも含まれる。
+                     */
+                    include_empty_categories?: boolean;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            category: components["schemas"]["ReadDocumentCategory"] | null;
+                            documents: components["schemas"]["ReadDocument"][];
+                        }[];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description フォームが存在しない */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description サーバーエラー */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/approval-requests/{id}/approve': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/documents/{document_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 資料を取得
+         * @description ### authの違いによる挙動の違い
+         *     - **exhibitor_bearerの場合**: 自分が属する参加団体の属性に基づいてアクセス可能な資料な場合取得
+         *     - **admin_oidcの場合**: 存在する資料を全て取得可能
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 資料のID */
+                    document_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReadDocument"];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** 資料を削除 */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description フォームID */
+                    document_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 削除成功 */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description フォームが存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** 資料を更新 */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 資料のID */
+                    document_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdateDocument"];
+                };
+            };
+            responses: {
+                /** @description Changed */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReadDocument"][];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** 承認申請を承認 */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 承認申請のID */
-          id: string;
+    "/document-categories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            /** @description 承認理由 */
-            approval_reason: string | null;
-          };
+        /** 資料カテゴリをすべて取得 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReadDocumentCategory"][];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-      };
-      responses: {
-        /** @description No Content */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        put?: never;
+        /** 資料カテゴリを新規作成 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreateDocumentCategory"];
+                };
+            };
+            responses: {
+                /** @description Changed */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReadDocumentCategory"];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description サーバーエラー */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/approval-requests/{id}/reject': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/document-categories/{category_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 資料カテゴリを取得 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 資料カテゴリのID */
+                    category_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReadDocumentCategory"];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** 資料カテゴリを削除 */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description カテゴリID */
+                    category_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 削除成功 */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description フォームが存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** 資料カテゴリを更新 */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 資料カテゴリのID */
+                    category_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdateDocumentCategory"];
+                };
+            };
+            responses: {
+                /** @description Changed */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReadDocumentCategory"][];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** 承認申請を却下 */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 承認申請のID */
-          id: string;
+    "/files/upload": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            /** @description 承認理由 */
-            approval_reason: string | null;
-          };
+        get?: never;
+        put?: never;
+        /** ファイルのアップロードurlを取得 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        file_name: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Changed */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            presigned_url: string;
+                            key: string;
+                        };
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-      };
-      responses: {
-        /** @description No Content */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description サーバーエラー */
-        500: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
+    "/files/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** ファイルのダウンロードurlを取得 */
+        get: {
+            parameters: {
+                query: {
+                    key: string;
+                    file_name: string;
+                    /** @description リダイレクトするかどうか．デフォルト値は`false` */
+                    redirect?: boolean;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Changed */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            presigned_url?: string;
+                        };
+                    };
+                };
+                /** @description redirect=trueの場合に返される．リソースへのリダイレクト */
+                302: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** ユーザーを全て取得 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserRead"][];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/{user_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * ユーザー情報を取得
+         * @description ### authの違いによる挙動の違い
+         *     - **exhibitor_bearerの場合**: ユーザーが自身の所属する参加団体に所属している場合のみ取得可能
+         *     - **admin_oidcの場合**: いかなるユーザー情報も取得可能
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description ユーザーID */
+                    user_id: components["schemas"]["UserId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserRead"];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** ユーザー情報を更新 */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description ユーザーID */
+                    user_id: components["schemas"]["UserId"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UserUpdate"];
+                };
+            };
+            responses: {
+                /** @description 更新成功 */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/users/{user_id}/notifications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** そのユーザー向けの通知と既読状況を取得 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description ユーザーID */
+                    user_id: components["schemas"]["UserId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            notification: components["schemas"]["NotificationRead"];
+                            /**
+                             * @description その通知が既読かどうかを示すフラグ
+                             *     trueの場合、通知は既読であることを示す
+                             */
+                            is_read: boolean;
+                        }[];
+                    };
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/{user_id}/approval_requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 承認申請をすべて取得 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description ユーザーのID */
+                    user_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReadApprovalRequest"][];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description サーバーエラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        /** 承認申請を新規作成 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description ユーザーのID */
+                    user_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreateApprovalRequest"];
+                };
+            };
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description サーバーエラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/{user_id}/approval_requests/{request_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 承認申請を取得 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description ユーザーのID */
+                    user_id: string;
+                    /** @description 承認申請のID */
+                    request_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReadApprovalRequest"];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 承認申請が存在しないか、アクセス権限がない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description サーバーエラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/{user_id}/approval_requests/{request_id}/close": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 承認申請を取り下げる */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description ユーザーのID */
+                    user_id: string;
+                    /** @description 承認申請のID */
+                    request_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description サーバーエラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/{user_id}/m_address": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** mアドレスを変更する */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description ユーザーのID */
+                    user_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /**
+                         * Format: email
+                         * @description 新しいmアドレス
+                         */
+                        m_address: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @description 新規mアドレスを有効化するためのアクティベーショントークン */
+                            activation_token?: string;
+                        };
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description サーバーエラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/notifications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 全ての通知を取得 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["NotificationRead"][];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        /** 通知を新規作成 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["NotificationCreate"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/notifications/{notification_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 通知を取得
+         * @description ### authの違いによる挙動の違い
+         *     - **exhibitor_bearerの場合**: 自分が通知対象である場合通知を取得可能
+         *     - **admin_oidcの場合**: 存在する通知を全て取得可能
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 通知id */
+                    notification_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["NotificationRead"];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** 通知を削除 */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 通知ID */
+                    notification_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description フォームが存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** 通知を更新 */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 通知ID */
+                    notification_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["NotificationUpdate"];
+                };
+            };
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/util/meta": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** ページのメタデータを取得 */
+        get: {
+            parameters: {
+                query: {
+                    /** @description フォームID */
+                    url: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @description The title of the page. */
+                            title: string | null;
+                            /** @description The description of the page. */
+                            description: string | null;
+                        };
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/approval-requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 承認申請をすべて取得 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReadApprovalRequest"][];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description サーバーエラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/approval-requests/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 承認申請を取得 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 承認申請のID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReadApprovalRequest"];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description サーバーエラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** 承認申請を削除 */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 承認申請のID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 削除成功 */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description フォームが存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description サーバーエラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/approval-requests/{id}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 承認申請を承認 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 承認申請のID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description 承認理由 */
+                        approval_reason: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description サーバーエラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/approval-requests/{id}/reject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 承認申請を却下 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 承認申請のID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description 承認理由 */
+                        approval_reason: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description サーバーエラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    BoothRead: {
-      /**
-       * Format: uuid
-       * @description 代表者1 ID
-       */
-      representative1: string;
-      /**
-       * Format: uuid
-       * @description 代表者2 ID
-       */
-      representative2: string;
-      /**
-       * Format: uuid
-       * @description 代表者3 ID
-       */
-      representative3: string;
-    };
-    GeneralRead: {
-      /**
-       * Format: uuid
-       * @description 代表者1 ID
-       */
-      representative1: string;
-      /**
-       * Format: uuid
-       * @description 代表者2 ID
-       */
-      representative2: string;
-      /**
-       * Format: uuid
-       * @description 代表者3 ID
-       */
-      representative3: string;
-    };
-    LaboRead: {
-      /**
-       * Format: uuid
-       * @description 代表者 ID
-       */
-      representative: string;
-    };
-    StageRead: {
-      /**
-       * Format: uuid
-       * @description 代表者1 ID
-       */
-      representative1: string;
-      /**
-       * Format: uuid
-       * @description 代表者2 ID
-       */
-      representative2: string;
-      /**
-       * Format: uuid
-       * @description 代表者3 ID
-       */
-      representative3: string;
-    };
-    PlanRead: {
-      type_booth?: components['schemas']['BoothRead'];
-      type_general?: components['schemas']['GeneralRead'];
-      type_labo?: components['schemas']['LaboRead'];
-      type_stage?: components['schemas']['StageRead'];
-    };
-    PressRead: {
-      /**
-       * Format: uuid
-       * @description 代表者ID
-       */
-      representative: string;
-    };
-    GroupRead: {
-      /** @description 団体ID */
-      readonly id: string;
-      /**
-       * Format: date-time
-       * @description 作成日時
-       */
-      readonly created_at: string;
-      /**
-       * Format: date-time
-       * @description 最終更新日時
-       */
-      readonly updated_at: string;
-      /**
-       * @description 団体名
-       * @example 工大祭実行委員会
-       */
-      name: string;
-      type_plan?: components['schemas']['PlanRead'];
-      type_press?: components['schemas']['PressRead'];
-    };
-    GroupId: string | 'us';
-    UserCreate: {
-      /**
-       * @description 名前
-       * @example Paul Johnson
-       */
-      name: string;
-      /**
-       * @description mアドレス(新旧どちらも含む)
-       * @example johnson.p.5703@m.isct.ac.jp
-       */
-      m_address: string;
-    };
-    BoothCreate: {
-      representative1: components['schemas']['UserCreate'];
-      representative2: components['schemas']['UserCreate'];
-      representative3: components['schemas']['UserCreate'];
-    };
-    GeneralCreate: {
-      representative1: components['schemas']['UserCreate'];
-      representative2: components['schemas']['UserCreate'];
-      representative3: components['schemas']['UserCreate'];
-    };
-    LaboCreate: {
-      representative: components['schemas']['UserCreate'];
-    };
-    StageCreate: {
-      representative1: components['schemas']['UserCreate'];
-      representative2: components['schemas']['UserCreate'];
-      representative3: components['schemas']['UserCreate'];
-    };
-    PlanCreate: {
-      type_booth?: components['schemas']['BoothCreate'];
-      type_general?: components['schemas']['GeneralCreate'];
-      type_labo?: components['schemas']['LaboCreate'];
-      type_stage?: components['schemas']['StageCreate'];
-    };
-    PressCreate: {
-      representative: components['schemas']['UserCreate'];
-    };
-    GroupCreate: {
-      /**
-       * @description 団体名
-       * @example 工大祭実行委員会
-       */
-      name: string;
-      type_plan?: components['schemas']['PlanCreate'];
-      type_press?: components['schemas']['PressCreate'];
-    };
-    PutGroupResponse: {
-      /** @description 団体新規作成により追加されたユーザーのactivation token */
-      activation_tokens: unknown;
-    };
-    BoothUpdate: {
-      /**
-       * Format: uuid
-       * @description 代表者1 ID
-       */
-      representative1?: string;
-      /**
-       * Format: uuid
-       * @description 代表者2 ID
-       */
-      representative2?: string;
-      /**
-       * Format: uuid
-       * @description 代表者3 ID
-       */
-      representative3?: string;
-    };
-    GeneralUpdate: {
-      /**
-       * Format: uuid
-       * @description 代表者1 ID
-       */
-      representative1?: string;
-      /**
-       * Format: uuid
-       * @description 代表者2 ID
-       */
-      representative2?: string;
-      /**
-       * Format: uuid
-       * @description 代表者3 ID
-       */
-      representative3?: string;
-    };
-    LaboUpdate: {
-      /**
-       * Format: uuid
-       * @description 代表者 ID
-       */
-      representative?: string;
-    };
-    StageUpdate: {
-      /**
-       * Format: uuid
-       * @description 代表者1 ID
-       */
-      representative1?: string;
-      /**
-       * Format: uuid
-       * @description 代表者2 ID
-       */
-      representative2?: string;
-      /**
-       * Format: uuid
-       * @description 代表者3 ID
-       */
-      representative3?: string;
-    };
-    PlanUpdate: {
-      type_booth?: components['schemas']['BoothUpdate'];
-      type_general?: components['schemas']['GeneralUpdate'];
-      type_labo?: components['schemas']['LaboUpdate'];
-      type_stage?: components['schemas']['StageUpdate'];
-    };
-    PressUpdate: {
-      /**
-       * Format: uuid
-       * @description 代表者ID
-       */
-      representative?: string;
-    };
-    GroupUpdate: {
-      /**
-       * @description 団体名
-       * @example 工大祭実行委員会
-       */
-      name?: string;
-      type_plan?: components['schemas']['PlanUpdate'];
-      type_press?: components['schemas']['PressUpdate'];
-    };
-    /** @description 当日販売される商品情報（読み取り用） */
-    ProductsRead: {
-      /** @description 商品の一覧 */
-      items: {
-        /** @description 商品名 */
-        name: string;
-        /** @description 値段 */
-        price: number | null;
-        /** @description トッピングやフレーバーなどのオプション */
-        options: {
-          /** @description 商品名 */
-          name: string;
-          /** @description 値段 */
-          price: number | null;
-        }[];
-      }[];
-      /** @description 商品全体の説明文 */
-      description: string;
-    };
-    PlanDetailsRead: {
-      product?: components['schemas']['ProductsRead'];
-      /** @description 追加情報（マークダウン形式） */
-      additional_info?: string | null;
-    };
-    /** @description 当日販売される商品情報（更新用） */
-    ProductsCreate: {
-      /** @description 商品の一覧 */
-      items?: {
-        /** @description 商品名 */
-        name?: string;
-        /** @description 値段 */
-        price?: number | null;
-        /** @description トッピングやフレーバーなどのオプション */
-        options?: {
-          /** @description 商品名 */
-          name?: string;
-          /** @description 値段 */
-          price?: number | null;
-        }[];
-      }[];
-      /** @description 商品全体の説明文 */
-      description?: string;
-    };
-    PlanDetailsCreate: {
-      product?: components['schemas']['ProductsCreate'];
-      /** @description 追加情報（マークダウン形式） */
-      additional_info?: string | null;
-    };
-    /** @description Target specifier for forms */
-    TargetSpecifier: string &
-      (
-        | (
-            | 'group/type/plan_general'
-            | 'group/type/plan_booth'
-            | 'group/type/plan_stage'
-            | 'group/type/plan_labo'
-            | 'group/type/press'
-            | 'user/nologin'
-          )
-        | unknown
-        | unknown
-      );
-    /** @description Generic form properties */
-    FormReadGeneric: {
-      /**
-       * Format: uuid
-       * @description Unique identifier
-       */
-      id: string;
-      /**
-       * Format: date-time
-       * @description Timestamp when the form was created
-       */
-      created_at: string;
-      /**
-       * Format: date-time
-       * @description Timestamp when the form was last updated
-       */
-      updated_at: string;
-      /**
-       * Format: uuid
-       * @description User ID of the creator
-       */
-      created_by: string;
-      /**
-       * Format: uuid
-       * @description User ID of the last updater
-       */
-      updated_by: string;
-      /** @description Target specifiers for the form */
-      targets: components['schemas']['TargetSpecifier'][];
-      /** @description Name of the form */
-      form_name: string;
-      /** @description Summary or description of the form */
-      summary: string;
-      /**
-       * Format: date-time
-       * @description Due date for the form submission
-       */
-      due_date: string | null;
-    };
-    /** @description フォームの一般情報 */
-    Info: {
-      /** @description 回答者に表示されるフォームのタイトル */
-      title: string;
-      /** @description 編集者に表示されるフォームのタイトル */
-      document_title: string;
-      /** @description フォームの説明 */
-      description: string;
-      /**
-       * Format: datetime
-       * @description フォームの回答期限
-       */
-      deadline?: string;
-    };
-    ItemGeneric: {
-      /**
-       * Format: uuid
-       * @description アイテムのID
-       */
-      readonly item_id: string;
-      /** @description 回答者に表示される項目のタイトル */
-      title: string;
-      /** @description 回答者に表示される項目の説明 */
-      description: string;
-    };
-    QuestionGeneric: {
-      /** @description 回答必須かどうか */
-      required: boolean;
-    };
-    /** @description テキスト */
-    QuestionText: {
-      /** @description trueの場合複数行にわたるテキスト。falseの場合一行の回答。 */
-      paragraph: boolean;
-    };
-    /** @description ラジオボタン */
-    QuestionRadioButton: {
-      /** @description 選択肢 */
-      choices: string[];
-    };
-    /** @description チェックボックス */
-    QuestionCheckBox: {
-      /** @description 選択肢 */
-      choices: string[];
-    };
-    /** @description フォームの質問 */
-    Question: components['schemas']['QuestionGeneric'] & {
-      question_text?: components['schemas']['QuestionText'];
-      question_radio_button?: components['schemas']['QuestionRadioButton'];
-      question_check_box?: components['schemas']['QuestionCheckBox'];
-    };
-    /** @description 一つの質問を含む項目 */
-    ItemQuestion: {
-      question: components['schemas']['Question'];
-    };
-    /** @description 改ページ */
-    ItemPageBreak: Record<string, never>;
-    /** @description テキスト */
-    ItemText: Record<string, never>;
-    /** @description フォームの単一の項目 */
-    Item: components['schemas']['ItemGeneric'] & {
-      item_question?: components['schemas']['ItemQuestion'];
-      item_page_break?: components['schemas']['ItemPageBreak'];
-      item_text?: components['schemas']['ItemText'];
-    };
-    /** @description フォーム */
-    Form: {
-      /**
-       * Format: uuid
-       * @description フォームID
-       */
-      readonly form_id?: string;
-      info: components['schemas']['Info'];
-      /** @description フォームのアイテムのリスト（質問、改ページ、テキストなど） */
-      items: components['schemas']['Item'][];
-    };
-    /** @description External form type */
-    FormReadTypeExternal: {
-      /**
-       * Format: uri
-       * @description URL of the external form
-       */
-      form_url: string;
-    };
-    /** @description Form read request */
-    FormRead:
-      | (components['schemas']['FormReadGeneric'] & {
-          type_builtin: components['schemas']['Form'];
-        })
-      | (components['schemas']['FormReadGeneric'] & {
-          type_external: components['schemas']['FormReadTypeExternal'];
+    schemas: {
+        BoothRead: {
+            /**
+             * Format: uuid
+             * @description 代表者1 ID
+             */
+            representative1: string;
+            /**
+             * Format: uuid
+             * @description 代表者2 ID
+             */
+            representative2: string;
+            /**
+             * Format: uuid
+             * @description 代表者3 ID
+             */
+            representative3: string;
+        };
+        GeneralRead: {
+            /**
+             * Format: uuid
+             * @description 代表者1 ID
+             */
+            representative1: string;
+            /**
+             * Format: uuid
+             * @description 代表者2 ID
+             */
+            representative2: string;
+            /**
+             * Format: uuid
+             * @description 代表者3 ID
+             */
+            representative3: string;
+        };
+        LaboRead: {
+            /**
+             * Format: uuid
+             * @description 代表者 ID
+             */
+            representative: string;
+        };
+        StageRead: {
+            /**
+             * Format: uuid
+             * @description 代表者1 ID
+             */
+            representative1: string;
+            /**
+             * Format: uuid
+             * @description 代表者2 ID
+             */
+            representative2: string;
+            /**
+             * Format: uuid
+             * @description 代表者3 ID
+             */
+            representative3: string;
+        };
+        PlanRead: {
+            type_booth?: components["schemas"]["BoothRead"];
+            type_general?: components["schemas"]["GeneralRead"];
+            type_labo?: components["schemas"]["LaboRead"];
+            type_stage?: components["schemas"]["StageRead"];
+        };
+        PressRead: {
+            /**
+             * Format: uuid
+             * @description 代表者ID
+             */
+            representative: string;
+        };
+        GroupRead: {
+            /** @description 団体ID */
+            readonly id: string;
+            /**
+             * Format: date-time
+             * @description 作成日時
+             */
+            readonly created_at: string;
+            /**
+             * Format: date-time
+             * @description 最終更新日時
+             */
+            readonly updated_at: string;
+            /**
+             * @description 団体名
+             * @example 工大祭実行委員会
+             */
+            name: string;
+            type_plan?: components["schemas"]["PlanRead"];
+            type_press?: components["schemas"]["PressRead"];
+        };
+        GroupId: string | "us";
+        UserCreate: {
+            /**
+             * @description 名前
+             * @example Paul Johnson
+             */
+            name: string;
+            /**
+             * @description mアドレス(新旧どちらも含む)
+             * @example johnson.p.5703@m.isct.ac.jp
+             */
+            m_address: string;
+        };
+        BoothCreate: {
+            representative1: components["schemas"]["UserCreate"];
+            representative2: components["schemas"]["UserCreate"];
+            representative3: components["schemas"]["UserCreate"];
+        };
+        GeneralCreate: {
+            representative1: components["schemas"]["UserCreate"];
+            representative2: components["schemas"]["UserCreate"];
+            representative3: components["schemas"]["UserCreate"];
+        };
+        LaboCreate: {
+            representative: components["schemas"]["UserCreate"];
+        };
+        StageCreate: {
+            representative1: components["schemas"]["UserCreate"];
+            representative2: components["schemas"]["UserCreate"];
+            representative3: components["schemas"]["UserCreate"];
+        };
+        PlanCreate: {
+            type_booth?: components["schemas"]["BoothCreate"];
+            type_general?: components["schemas"]["GeneralCreate"];
+            type_labo?: components["schemas"]["LaboCreate"];
+            type_stage?: components["schemas"]["StageCreate"];
+        };
+        PressCreate: {
+            representative: components["schemas"]["UserCreate"];
+        };
+        GroupCreate: {
+            /**
+             * @description 団体名
+             * @example 工大祭実行委員会
+             */
+            name: string;
+            type_plan?: components["schemas"]["PlanCreate"];
+            type_press?: components["schemas"]["PressCreate"];
+        };
+        PutGroupResponse: {
+            /** @description 団体新規作成により追加されたユーザーのactivation token */
+            activation_tokens: unknown;
+        };
+        BoothUpdate: {
+            /**
+             * Format: uuid
+             * @description 代表者1 ID
+             */
+            representative1?: string;
+            /**
+             * Format: uuid
+             * @description 代表者2 ID
+             */
+            representative2?: string;
+            /**
+             * Format: uuid
+             * @description 代表者3 ID
+             */
+            representative3?: string;
+        };
+        GeneralUpdate: {
+            /**
+             * Format: uuid
+             * @description 代表者1 ID
+             */
+            representative1?: string;
+            /**
+             * Format: uuid
+             * @description 代表者2 ID
+             */
+            representative2?: string;
+            /**
+             * Format: uuid
+             * @description 代表者3 ID
+             */
+            representative3?: string;
+        };
+        LaboUpdate: {
+            /**
+             * Format: uuid
+             * @description 代表者 ID
+             */
+            representative?: string;
+        };
+        StageUpdate: {
+            /**
+             * Format: uuid
+             * @description 代表者1 ID
+             */
+            representative1?: string;
+            /**
+             * Format: uuid
+             * @description 代表者2 ID
+             */
+            representative2?: string;
+            /**
+             * Format: uuid
+             * @description 代表者3 ID
+             */
+            representative3?: string;
+        };
+        PlanUpdate: {
+            type_booth?: components["schemas"]["BoothUpdate"];
+            type_general?: components["schemas"]["GeneralUpdate"];
+            type_labo?: components["schemas"]["LaboUpdate"];
+            type_stage?: components["schemas"]["StageUpdate"];
+        };
+        PressUpdate: {
+            /**
+             * Format: uuid
+             * @description 代表者ID
+             */
+            representative?: string;
+        };
+        GroupUpdate: {
+            /**
+             * @description 団体名
+             * @example 工大祭実行委員会
+             */
+            name?: string;
+            type_plan?: components["schemas"]["PlanUpdate"];
+            type_press?: components["schemas"]["PressUpdate"];
+        };
+        /** @description 当日販売される商品情報（読み取り用） */
+        ProductsRead: {
+            /** @description 商品の一覧 */
+            items: {
+                /** @description 商品名 */
+                name: string;
+                /** @description 値段 */
+                price: number | null;
+                /** @description トッピングやフレーバーなどのオプション */
+                options: {
+                    /** @description 商品名 */
+                    name: string;
+                    /** @description 値段 */
+                    price: number | null;
+                }[];
+            }[];
+            /** @description 商品全体の説明文 */
+            description: string;
+        };
+        PlanDetailsRead: {
+            product?: components["schemas"]["ProductsRead"];
+            /** @description 追加情報（マークダウン形式） */
+            additional_info?: string | null;
+        };
+        /** @description 当日販売される商品情報（更新用） */
+        ProductsCreate: {
+            /** @description 商品の一覧 */
+            items?: {
+                /** @description 商品名 */
+                name?: string;
+                /** @description 値段 */
+                price?: number | null;
+                /** @description トッピングやフレーバーなどのオプション */
+                options?: {
+                    /** @description 商品名 */
+                    name?: string;
+                    /** @description 値段 */
+                    price?: number | null;
+                }[];
+            }[];
+            /** @description 商品全体の説明文 */
+            description?: string;
+        };
+        PlanDetailsCreate: {
+            product?: components["schemas"]["ProductsCreate"];
+            /** @description 追加情報（マークダウン形式） */
+            additional_info?: string | null;
+        };
+        /** @description Target specifier for forms */
+        TargetSpecifier: string & (("group/type/plan_general" | "group/type/plan_booth" | "group/type/plan_stage" | "group/type/plan_labo" | "group/type/press" | "user/nologin") | unknown | unknown);
+        /** @description Generic form properties */
+        FormReadGeneric: {
+            /**
+             * Format: uuid
+             * @description Unique identifier
+             */
+            id: string;
+            /**
+             * Format: date-time
+             * @description Timestamp when the form was created
+             */
+            created_at: string;
+            /**
+             * Format: date-time
+             * @description Timestamp when the form was last updated
+             */
+            updated_at: string;
+            /**
+             * Format: uuid
+             * @description User ID of the creator
+             */
+            created_by: string;
+            /**
+             * Format: uuid
+             * @description User ID of the last updater
+             */
+            updated_by: string;
+            /** @description Target specifiers for the form */
+            targets: components["schemas"]["TargetSpecifier"][];
+            /** @description Name of the form */
+            form_name: string;
+            /** @description Summary or description of the form */
+            summary: string;
+            /**
+             * Format: date-time
+             * @description Due date for the form submission
+             */
+            due_date: string | null;
+        };
+        /** @description フォームの一般情報 */
+        Info: {
+            /** @description 回答者に表示されるフォームのタイトル */
+            title: string;
+            /** @description 編集者に表示されるフォームのタイトル */
+            document_title: string;
+            /** @description フォームの説明 */
+            description: string;
+            /**
+             * Format: datetime
+             * @description フォームの回答期限
+             */
+            deadline?: string;
+        };
+        ItemGeneric: {
+            /**
+             * Format: uuid
+             * @description アイテムのID
+             */
+            readonly item_id: string;
+            /** @description 回答者に表示される項目のタイトル */
+            title: string;
+            /** @description 回答者に表示される項目の説明 */
+            description: string;
+        };
+        QuestionGeneric: {
+            /** @description 回答必須かどうか */
+            required: boolean;
+        };
+        /** @description テキスト */
+        QuestionText: {
+            /** @description trueの場合複数行にわたるテキスト。falseの場合一行の回答。 */
+            paragraph: boolean;
+        };
+        /** @description ラジオボタン */
+        QuestionRadioButton: {
+            /** @description 選択肢 */
+            choices: string[];
+        };
+        /** @description チェックボックス */
+        QuestionCheckBox: {
+            /** @description 選択肢 */
+            choices: string[];
+        };
+        /** @description フォームの質問 */
+        Question: components["schemas"]["QuestionGeneric"] & {
+            question_text?: components["schemas"]["QuestionText"];
+            question_radio_button?: components["schemas"]["QuestionRadioButton"];
+            question_check_box?: components["schemas"]["QuestionCheckBox"];
+        };
+        /** @description 一つの質問を含む項目 */
+        ItemQuestion: {
+            question: components["schemas"]["Question"];
+        };
+        /** @description 改ページ */
+        ItemPageBreak: Record<string, never>;
+        /** @description テキスト */
+        ItemText: Record<string, never>;
+        /** @description フォームの単一の項目 */
+        Item: components["schemas"]["ItemGeneric"] & {
+            item_question?: components["schemas"]["ItemQuestion"];
+            item_page_break?: components["schemas"]["ItemPageBreak"];
+            item_text?: components["schemas"]["ItemText"];
+        };
+        /** @description フォーム */
+        Form: {
+            /**
+             * Format: uuid
+             * @description フォームID
+             */
+            readonly form_id?: string;
+            info: components["schemas"]["Info"];
+            /** @description フォームのアイテムのリスト（質問、改ページ、テキストなど） */
+            items: components["schemas"]["Item"][];
+        };
+        /** @description External form type */
+        FormReadTypeExternal: {
+            /**
+             * Format: uri
+             * @description URL of the external form
+             */
+            form_url: string;
+        };
+        /** @description Form read request */
+        FormRead: (components["schemas"]["FormReadGeneric"] & {
+            type_builtin: components["schemas"]["Form"];
+        }) | (components["schemas"]["FormReadGeneric"] & {
+            type_external: components["schemas"]["FormReadTypeExternal"];
         });
-    /** @description Generic form properties */
-    FormCreateGeneric: {
-      /** @description Target specifiers for the form */
-      targets: components['schemas']['TargetSpecifier'][];
-      /** @description Name of the form */
-      form_name: string;
-      /** @description Summary or description of the form */
-      summary: string;
-      /**
-       * Format: date-time
-       * @description Due date for the form submission
-       */
-      due_date: string | null;
-    };
-    /** @description External form type */
-    FormCreateTypeExternal: {
-      /**
-       * Format: uri
-       * @description URL of the external form
-       */
-      form_url: string;
-    };
-    /** @description Form creation request */
-    FormCreate: components['schemas']['FormCreateGeneric'] &
-      (
-        | {
-            type_builtin: components['schemas']['Form'];
-          }
-        | {
-            type_external: components['schemas']['FormCreateTypeExternal'];
-          }
-      );
-    /** @description Generic form properties */
-    FormUpdateGeneric: {
-      /** @description Target specifiers for the form */
-      targets?: components['schemas']['TargetSpecifier'][];
-      /** @description Name of the form */
-      form_name?: string;
-      /** @description Summary or description of the form */
-      summary?: string;
-      /**
-       * Format: date-time
-       * @description Due date for the form submission
-       */
-      due_date?: string | null;
-    };
-    /** @description External form type */
-    FormUpdateTypeExternal: {
-      /**
-       * Format: uri
-       * @description URL of the external form
-       */
-      form_url?: string;
-    };
-    FormUpdate:
-      | (components['schemas']['FormUpdateGeneric'] & {
-          type_builtin: components['schemas']['Form'];
-        })
-      | (components['schemas']['FormUpdateGeneric'] & {
-          type_external: components['schemas']['FormUpdateTypeExternal'];
-        })
-      | components['schemas']['FormUpdateGeneric'];
-    ReadDocumentGeneric: {
-      /** Format: uuid */
-      id: string;
-      /** Format: date-time */
-      created_at: string;
-      /** Format: date-time */
-      updated_at: string;
-      /** Format: uuid */
-      created_by: string;
-      /** Format: uuid */
-      updated_by: string;
-      title: string;
-      /** Format: uuid */
-      category: string | null;
-      /** @description Target specifiers for the form */
-      targets: components['schemas']['TargetSpecifier'][];
-    };
-    /** @description マークダウン形式の資料 */
-    ReadDocumentFormatMarkdown: {
-      content: string;
-    };
-    /** @description pdf形式の資料 */
-    ReadDocumentFormatPdf: {
-      file_key: string;
-      file_name: string;
-    };
-    /** @description 任意形式の資料 */
-    ReadDocumentFormatMisc: {
-      file_key: string;
-      file_name: string;
-    };
-    ReadDocument: components['schemas']['ReadDocumentGeneric'] & {
-      format_markdown?: components['schemas']['ReadDocumentFormatMarkdown'];
-      format_pdf?: components['schemas']['ReadDocumentFormatPdf'];
-      format_misc?: components['schemas']['ReadDocumentFormatMisc'];
-    };
-    CreateDocumentGeneric: {
-      title: string;
-      /** Format: uuid */
-      category: string | null;
-      /** @description Target specifiers for the form */
-      targets: components['schemas']['TargetSpecifier'][];
-    };
-    /** @description マークダウン形式の資料 */
-    CreateDocumentFormatMarkdown: {
-      content: string;
-    };
-    /** @description pdf形式の資料 */
-    CreateDocumentFormatPdf: {
-      file_key: string;
-      file_name: string;
-    };
-    /** @description 任意形式の資料 */
-    CreateDocumentFormatMisc: {
-      file_key: string;
-      file_name: string;
-    };
-    CreateDocument: components['schemas']['CreateDocumentGeneric'] & {
-      format_markdown?: components['schemas']['CreateDocumentFormatMarkdown'];
-      format_pdf?: components['schemas']['CreateDocumentFormatPdf'];
-      format_misc?: components['schemas']['CreateDocumentFormatMisc'];
-    };
-    /** @description 資料のカテゴリー */
-    ReadDocumentCategory: {
-      /** Format: uuid */
-      id: string;
-      /** Format: date-time */
-      created_at: string;
-      /** Format: date-time */
-      updated_at: string;
-      title: string;
-      emoji: string | null;
-    };
-    UpdateDocumentGeneric: {
-      title?: string;
-      /** Format: uuid */
-      category?: string | null;
-      /** @description Target specifiers for the form */
-      targets?: components['schemas']['TargetSpecifier'][];
-    };
-    /** @description マークダウン形式の資料 */
-    UpdateDocumentFormatMarkdown: {
-      content: string;
-    };
-    /** @description pdf形式の資料 */
-    UpdateDocumentFormatPdf: {
-      file_key: string;
-      file_name: string;
-    };
-    /** @description 任意形式の資料 */
-    UpdateDocumentFormatMisc: {
-      file_key: string;
-      file_name: string;
-    };
-    UpdateDocument:
-      | (components['schemas']['UpdateDocumentGeneric'] & {
-          format_markdown?: components['schemas']['UpdateDocumentFormatMarkdown'];
-        })
-      | (components['schemas']['UpdateDocumentGeneric'] & {
-          format_pdf?: components['schemas']['UpdateDocumentFormatPdf'];
-        })
-      | (components['schemas']['UpdateDocumentGeneric'] & {
-          format_misc?: components['schemas']['UpdateDocumentFormatMisc'];
-        })
-      | components['schemas']['UpdateDocumentGeneric'];
-    /** @description 資料のカテゴリー */
-    CreateDocumentCategory: {
-      title: string;
-      emoji: string | null;
-    };
-    /** @description 資料のカテゴリー */
-    UpdateDocumentCategory: {
-      title?: string;
-      emoji?: string | null;
-    };
-    UserRead: {
-      /**
-       * Format: uuid
-       * @description unique id
-       */
-      readonly id: string;
-      /**
-       * Format: date-time
-       * @description 作成日時
-       */
-      readonly created_at: string;
-      /**
-       * Format: date-time
-       * @description 最終更新日時
-       */
-      readonly updated_at: string;
-      /**
-       * @description 名前
-       * @example Paul Johnson
-       */
-      name: string;
-      /**
-       * @description mアドレス(新旧どちらも含む)
-       * @example johnson.p.5703@m.isct.ac.jp
-       */
-      m_address: string;
-      /**
-       * @description 団体id
-       * @example T-001
-       */
-      group_id: string;
-    };
-    UserId: string | 'me';
-    UserUpdate: {
-      /**
-       * @description 名前
-       * @example Paul Johnson
-       */
-      name?: string;
-      /**
-       * @description mアドレス(新旧どちらも含む)
-       * @example johnson.p.5703@m.isct.ac.jp
-       */
-      m_address?: string;
-    };
-    NotificationReadGeneric: {
-      /**
-       * Format: uuid
-       * @description 通知ID
-       */
-      id: string;
-      /**
-       * Format: date-time
-       * @description 作成日時
-       */
-      created_at: string;
-      /**
-       * Format: date-time
-       * @description 最終更新日時
-       */
-      updated_at: string;
-      /**
-       * Format: uuid
-       * @description 作成者のユーザーID
-       */
-      created_by: string;
-      /**
-       * Format: uuid
-       * @description 最終更新者のユーザーID
-       */
-      updated_by: string;
-      /** @description Target specifiers for the form */
-      target: components['schemas']['TargetSpecifier'][];
-    };
-    /** @description マークダウンタイプの通知 */
-    NotificationReadTypeMarkdown: {
-      /** @description 通知のタイトル */
-      title: string;
-      content: string;
-    };
-    /** @description 承認申請の通知タイプ */
-    NotificationReadTypeApprovalRequest: {
-      /**
-       * Format: uuid
-       * @description 承認申請のID
-       */
-      approval_request_id: string;
-    };
-    NotificationRead:
-      | (components['schemas']['NotificationReadGeneric'] & {
-          type_markdown: components['schemas']['NotificationReadTypeMarkdown'];
-        })
-      | (components['schemas']['NotificationReadGeneric'] & {
-          type_approval_request: components['schemas']['NotificationReadTypeApprovalRequest'];
+        /** @description Generic form properties */
+        FormCreateGeneric: {
+            /** @description Target specifiers for the form */
+            targets: components["schemas"]["TargetSpecifier"][];
+            /** @description Name of the form */
+            form_name: string;
+            /** @description Summary or description of the form */
+            summary: string;
+            /**
+             * Format: date-time
+             * @description Due date for the form submission
+             */
+            due_date: string | null;
+        };
+        /** @description External form type */
+        FormCreateTypeExternal: {
+            /**
+             * Format: uri
+             * @description URL of the external form
+             */
+            form_url: string;
+        };
+        /** @description Form creation request */
+        FormCreate: components["schemas"]["FormCreateGeneric"] & ({
+            type_builtin: components["schemas"]["Form"];
+        } | {
+            type_external: components["schemas"]["FormCreateTypeExternal"];
         });
-    /**
-     * @description Status of the approval request
-     * @example pending
-     * @enum {string}
-     */
-    ApprovalRequestStatus: 'pending' | 'approved' | 'rejected' | 'closed';
-    /** @description 企画情報訂正申請 */
-    ApprovalRequestTypeEditExhibitionInfo: {
-      /** @description 企画内容説明文 */
-      description?: string;
-      /** @description 企画アイコンのキー． */
-      icon_key?: string;
-    };
-    /** @description Type of the approval request */
-    ApprovalRequestType: {
-      type_edit_exhibition_info: components['schemas']['ApprovalRequestTypeEditExhibitionInfo'];
-    };
-    /** @description Response for reading an approval request */
-    ReadApprovalRequest: {
-      /**
-       * Format: uuid
-       * @description ID of the approval request
-       */
-      id: string;
-      /**
-       * Format: date-time
-       * @description Time when the approval request was issued
-       */
-      issued_at: string;
-      /**
-       * Format: uuid
-       * @description ID of the user who issued the approval request
-       */
-      issued_by: string;
-      status: components['schemas']['ApprovalRequestStatus'];
-      /**
-       * Format: uuid
-       * @description ID of the user who approved or rejected the request
-       */
-      approved_by?: string | null;
-      /** @description Reason for issuing the approval request */
-      issue_reason: string;
-      /** @description Reason for approving or rejecting the request */
-      approval_reason: string | null;
-    } & components['schemas']['ApprovalRequestType'];
-    /** @description Request to create an approval request */
-    CreateApprovalRequest: components['schemas']['ApprovalRequestType'] & {
-      /** @description 承認申請の理由 */
-      issue_reason?: string;
-    };
-    NotificationCreateGeneric: {
-      /** @description Target specifiers for the form */
-      target: components['schemas']['TargetSpecifier'][];
-    };
-    /** @description マークダウンタイプの通知 */
-    NotificationCreateTypeMarkdown: {
-      /** @description 通知のタイトル */
-      title: string;
-      content: string;
-    };
-    /** @description 承認申請の通知タイプ */
-    NotificationCreateTypeApprovalRequest: {
-      /**
-       * Format: uuid
-       * @description 承認申請のID
-       */
-      approval_request_id: string;
-    };
-    NotificationCreate:
-      | (components['schemas']['NotificationCreateGeneric'] & {
-          type_markdown: components['schemas']['NotificationCreateTypeMarkdown'];
-        })
-      | (components['schemas']['NotificationCreateGeneric'] & {
-          type_approval_request: components['schemas']['NotificationCreateTypeApprovalRequest'];
+        /** @description Generic form properties */
+        FormUpdateGeneric: {
+            /** @description Target specifiers for the form */
+            targets?: components["schemas"]["TargetSpecifier"][];
+            /** @description Name of the form */
+            form_name?: string;
+            /** @description Summary or description of the form */
+            summary?: string;
+            /**
+             * Format: date-time
+             * @description Due date for the form submission
+             */
+            due_date?: string | null;
+        };
+        /** @description External form type */
+        FormUpdateTypeExternal: {
+            /**
+             * Format: uri
+             * @description URL of the external form
+             */
+            form_url?: string;
+        };
+        FormUpdate: (components["schemas"]["FormUpdateGeneric"] & {
+            type_builtin: components["schemas"]["Form"];
+        }) | (components["schemas"]["FormUpdateGeneric"] & {
+            type_external: components["schemas"]["FormUpdateTypeExternal"];
+        }) | components["schemas"]["FormUpdateGeneric"];
+        ReadDocumentGeneric: {
+            /** Format: uuid */
+            id: string;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+            /** Format: uuid */
+            created_by: string;
+            /** Format: uuid */
+            updated_by: string;
+            title: string;
+            /** Format: uuid */
+            category: string | null;
+            /** @description Target specifiers for the form */
+            targets: components["schemas"]["TargetSpecifier"][];
+        };
+        /** @description マークダウン形式の資料 */
+        ReadDocumentFormatMarkdown: {
+            content: string;
+        };
+        /** @description pdf形式の資料 */
+        ReadDocumentFormatPdf: {
+            file_key: string;
+            file_name: string;
+        };
+        /** @description 任意形式の資料 */
+        ReadDocumentFormatMisc: {
+            file_key: string;
+            file_name: string;
+        };
+        ReadDocument: components["schemas"]["ReadDocumentGeneric"] & {
+            format_markdown?: components["schemas"]["ReadDocumentFormatMarkdown"];
+            format_pdf?: components["schemas"]["ReadDocumentFormatPdf"];
+            format_misc?: components["schemas"]["ReadDocumentFormatMisc"];
+        };
+        CreateDocumentGeneric: {
+            title: string;
+            /** Format: uuid */
+            category: string | null;
+            /** @description Target specifiers for the form */
+            targets: components["schemas"]["TargetSpecifier"][];
+        };
+        /** @description マークダウン形式の資料 */
+        CreateDocumentFormatMarkdown: {
+            content: string;
+        };
+        /** @description pdf形式の資料 */
+        CreateDocumentFormatPdf: {
+            file_key: string;
+            file_name: string;
+        };
+        /** @description 任意形式の資料 */
+        CreateDocumentFormatMisc: {
+            file_key: string;
+            file_name: string;
+        };
+        CreateDocument: components["schemas"]["CreateDocumentGeneric"] & {
+            format_markdown?: components["schemas"]["CreateDocumentFormatMarkdown"];
+            format_pdf?: components["schemas"]["CreateDocumentFormatPdf"];
+            format_misc?: components["schemas"]["CreateDocumentFormatMisc"];
+        };
+        /** @description 資料のカテゴリー */
+        ReadDocumentCategory: {
+            /** Format: uuid */
+            id: string;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+            title: string;
+            emoji: string | null;
+        };
+        UpdateDocumentGeneric: {
+            title?: string;
+            /** Format: uuid */
+            category?: string | null;
+            /** @description Target specifiers for the form */
+            targets?: components["schemas"]["TargetSpecifier"][];
+        };
+        /** @description マークダウン形式の資料 */
+        UpdateDocumentFormatMarkdown: {
+            content: string;
+        };
+        /** @description pdf形式の資料 */
+        UpdateDocumentFormatPdf: {
+            file_key: string;
+            file_name: string;
+        };
+        /** @description 任意形式の資料 */
+        UpdateDocumentFormatMisc: {
+            file_key: string;
+            file_name: string;
+        };
+        UpdateDocument: (components["schemas"]["UpdateDocumentGeneric"] & {
+            format_markdown?: components["schemas"]["UpdateDocumentFormatMarkdown"];
+        }) | (components["schemas"]["UpdateDocumentGeneric"] & {
+            format_pdf?: components["schemas"]["UpdateDocumentFormatPdf"];
+        }) | (components["schemas"]["UpdateDocumentGeneric"] & {
+            format_misc?: components["schemas"]["UpdateDocumentFormatMisc"];
+        }) | components["schemas"]["UpdateDocumentGeneric"];
+        /** @description 資料のカテゴリー */
+        CreateDocumentCategory: {
+            title: string;
+            emoji: string | null;
+        };
+        /** @description 資料のカテゴリー */
+        UpdateDocumentCategory: {
+            title?: string;
+            emoji?: string | null;
+        };
+        UserRead: {
+            /**
+             * Format: uuid
+             * @description unique id
+             */
+            readonly id: string;
+            /**
+             * Format: date-time
+             * @description 作成日時
+             */
+            readonly created_at: string;
+            /**
+             * Format: date-time
+             * @description 最終更新日時
+             */
+            readonly updated_at: string;
+            /**
+             * @description 名前
+             * @example Paul Johnson
+             */
+            name: string;
+            /**
+             * @description mアドレス(新旧どちらも含む)
+             * @example johnson.p.5703@m.isct.ac.jp
+             */
+            m_address: string;
+            /**
+             * @description 団体id
+             * @example T-001
+             */
+            group_id: string;
+        };
+        UserId: string | "me";
+        UserUpdate: {
+            /**
+             * @description 名前
+             * @example Paul Johnson
+             */
+            name?: string;
+            /**
+             * @description mアドレス(新旧どちらも含む)
+             * @example johnson.p.5703@m.isct.ac.jp
+             */
+            m_address?: string;
+        };
+        NotificationReadGeneric: {
+            /**
+             * Format: uuid
+             * @description 通知ID
+             */
+            id: string;
+            /**
+             * Format: date-time
+             * @description 作成日時
+             */
+            created_at: string;
+            /**
+             * Format: date-time
+             * @description 最終更新日時
+             */
+            updated_at: string;
+            /**
+             * Format: uuid
+             * @description 作成者のユーザーID
+             */
+            created_by: string;
+            /**
+             * Format: uuid
+             * @description 最終更新者のユーザーID
+             */
+            updated_by: string;
+            /** @description Target specifiers for the form */
+            target: components["schemas"]["TargetSpecifier"][];
+        };
+        /** @description マークダウンタイプの通知 */
+        NotificationReadTypeMarkdown: {
+            /** @description 通知のタイトル */
+            title: string;
+            content: string;
+        };
+        /** @description 承認申請の通知タイプ */
+        NotificationReadTypeApprovalRequest: {
+            /**
+             * Format: uuid
+             * @description 承認申請のID
+             */
+            approval_request_id: string;
+        };
+        NotificationRead: (components["schemas"]["NotificationReadGeneric"] & {
+            type_markdown: components["schemas"]["NotificationReadTypeMarkdown"];
+        }) | (components["schemas"]["NotificationReadGeneric"] & {
+            type_approval_request: components["schemas"]["NotificationReadTypeApprovalRequest"];
         });
-    NotificationUpdateGeneric: {
-      /** @description Target specifiers for the form */
-      target?: components['schemas']['TargetSpecifier'][];
-    };
-    /** @description マークダウンタイプの通知 */
-    NotificationUpdateTypeMarkdown: {
-      /** @description 通知のタイトル */
-      title?: string;
-      content?: string;
-    };
-    /** @description 承認申請の通知タイプ */
-    NotificationUpdateTypeApprovalRequest: {
-      /**
-       * Format: uuid
-       * @description 承認申請のID
-       */
-      approval_request_id?: string;
-    };
-    NotificationUpdate:
-      | (components['schemas']['NotificationUpdateGeneric'] & {
-          type_markdown: components['schemas']['NotificationUpdateTypeMarkdown'];
-        })
-      | (components['schemas']['NotificationUpdateGeneric'] & {
-          type_approval_request: components['schemas']['NotificationUpdateTypeApprovalRequest'];
+        /**
+         * @description Status of the approval request
+         * @example pending
+         * @enum {string}
+         */
+        ApprovalRequestStatus: "pending" | "approved" | "rejected" | "closed";
+        /** @description 企画情報訂正申請 */
+        ApprovalRequestTypeEditExhibitionInfo: {
+            /** @description 企画内容説明文 */
+            description?: string;
+            /** @description 企画アイコンのキー． */
+            icon_key?: string;
+        };
+        /** @description Type of the approval request */
+        ApprovalRequestType: {
+            type_edit_exhibition_info: components["schemas"]["ApprovalRequestTypeEditExhibitionInfo"];
+        };
+        /** @description Response for reading an approval request */
+        ReadApprovalRequest: {
+            /**
+             * Format: uuid
+             * @description ID of the approval request
+             */
+            id: string;
+            /**
+             * Format: date-time
+             * @description Time when the approval request was issued
+             */
+            issued_at: string;
+            /**
+             * Format: uuid
+             * @description ID of the user who issued the approval request
+             */
+            issued_by: string;
+            status: components["schemas"]["ApprovalRequestStatus"];
+            /**
+             * Format: uuid
+             * @description ID of the user who approved or rejected the request
+             */
+            approved_by?: string | null;
+            /** @description Reason for issuing the approval request */
+            issue_reason: string;
+            /** @description Reason for approving or rejecting the request */
+            approval_reason: string | null;
+        } & components["schemas"]["ApprovalRequestType"];
+        /** @description Request to create an approval request */
+        CreateApprovalRequest: components["schemas"]["ApprovalRequestType"] & {
+            /** @description 承認申請の理由 */
+            issue_reason?: string;
+        };
+        NotificationCreateGeneric: {
+            /** @description Target specifiers for the form */
+            target: components["schemas"]["TargetSpecifier"][];
+        };
+        /** @description マークダウンタイプの通知 */
+        NotificationCreateTypeMarkdown: {
+            /** @description 通知のタイトル */
+            title: string;
+            content: string;
+        };
+        /** @description 承認申請の通知タイプ */
+        NotificationCreateTypeApprovalRequest: {
+            /**
+             * Format: uuid
+             * @description 承認申請のID
+             */
+            approval_request_id: string;
+        };
+        NotificationCreate: (components["schemas"]["NotificationCreateGeneric"] & {
+            type_markdown: components["schemas"]["NotificationCreateTypeMarkdown"];
+        }) | (components["schemas"]["NotificationCreateGeneric"] & {
+            type_approval_request: components["schemas"]["NotificationCreateTypeApprovalRequest"];
         });
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+        NotificationUpdateGeneric: {
+            /** @description Target specifiers for the form */
+            target?: components["schemas"]["TargetSpecifier"][];
+        };
+        /** @description マークダウンタイプの通知 */
+        NotificationUpdateTypeMarkdown: {
+            /** @description 通知のタイトル */
+            title?: string;
+            content?: string;
+        };
+        /** @description 承認申請の通知タイプ */
+        NotificationUpdateTypeApprovalRequest: {
+            /**
+             * Format: uuid
+             * @description 承認申請のID
+             */
+            approval_request_id?: string;
+        };
+        NotificationUpdate: (components["schemas"]["NotificationUpdateGeneric"] & {
+            type_markdown: components["schemas"]["NotificationUpdateTypeMarkdown"];
+        }) | (components["schemas"]["NotificationUpdateGeneric"] & {
+            type_approval_request: components["schemas"]["NotificationUpdateTypeApprovalRequest"];
+        });
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export type operations = Record<string, never>;

--- a/libs/shared-types/src/auth_v1.d.ts
+++ b/libs/shared-types/src/auth_v1.d.ts
@@ -4,600 +4,600 @@
  */
 
 export interface paths {
-  '/activate': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/activate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** ユーザーを有効化する。 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["Activate"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description トークンが不正 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description ユーザーが存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description ユーザーが既に有効化されている */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description レート制限 */
+                429: {
+                    headers: {
+                        /** @description rate limitがリセットされるまでの秒数 */
+                        "ratelimit-reset"?: number;
+                        /** @description 再試行可能になるまでの秒数 */
+                        "retry-after"?: number;
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** ユーザーを有効化する。 */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['Activate'];
+    "/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      responses: {
-        /** @description OK */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        get?: never;
+        put?: never;
+        /** 資格情報を検証し、アクセストークンとリフレッシュトークンを発行する。 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["Login"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["LoginSuccess"];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description リクエストが多すぎる場合 */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description トークンが不正 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description ユーザーが存在しない */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description ユーザーが既に有効化されている */
-        409: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description レート制限 */
-        429: {
-          headers: {
-            /** @description rate limitがリセットされるまでの秒数 */
-            'ratelimit-reset'?: number;
-            /** @description 再試行可能になるまでの秒数 */
-            'retry-after'?: number;
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/login': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** リフレッシュトークンを検証し、アクセストークンを発行する。 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["Refresh"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["LoginSuccess"];
+                    };
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** 資格情報を検証し、アクセストークンとリフレッシュトークンを発行する。 */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['Login'];
+    "/password/change": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['LoginSuccess'];
-          };
+        get?: never;
+        put?: never;
+        /** パスワードの変更 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["PasswordChange"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description リクエストが多すぎる場合 */
-        429: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/refresh': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/password/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * パスワードリセットリクエスト
+         * @description ユーザーがパスワードを忘れた場合に、パスワードリセットのためのメールを送信します。
+         *     メールアドレスを指定してリクエストを行います。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["PasswordReset"];
+                };
+            };
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** リフレッシュトークンを検証し、アクセストークンを発行する。 */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['Refresh'];
+    "/password/reset/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['LoginSuccess'];
-          };
+        get?: never;
+        put?: never;
+        /**
+         * パスワードのリセット承認
+         * @description パスワードリセットトークンが有効であることを確認し、パスワードリセットを承認します。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["PasswordResetConfirm"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/password/change': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/revoke": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** リフレッシュトークンとそれから生成されたアクセストークンを失効させる。 */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["Revoke"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正なrequest bodyの形式 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 資格情報が無効だった場合 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** パスワードの変更 */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['PasswordChange'];
+    "/admin/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        /** OIDCの認証エンドポイントまでリダイレクト */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Found. */
+                302: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/password/reset': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/admin/redirect": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** OIDCのリダイレクトエンドポイント */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["AdminRedirectPayload"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["LoginSuccess"];
+                    };
+                };
+                /** @description セッションが無効な場合 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * パスワードリセットリクエスト
-     * @description ユーザーがパスワードを忘れた場合に、パスワードリセットのためのメールを送信します。
-     *     メールアドレスを指定してリクエストを行います。
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['PasswordReset'];
-        };
-      };
-      responses: {
-        /** @description No Content */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/password/reset/confirm': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * パスワードのリセット承認
-     * @description パスワードリセットトークンが有効であることを確認し、パスワードリセットを承認します。
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['PasswordResetConfirm'];
-        };
-      };
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/revoke': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** リフレッシュトークンとそれから生成されたアクセストークンを失効させる。 */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['Revoke'];
-        };
-      };
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 不正なrequest bodyの形式 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 資格情報が無効だった場合 */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/admin/login': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** OIDCの認証エンドポイントまでリダイレクト */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Found. */
-        302: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/admin/redirect': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** OIDCのリダイレクトエンドポイント */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['AdminRedirectPayload'];
-        };
-      };
-      responses: {
-        /** @description OK */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['LoginSuccess'];
-          };
-        };
-        /** @description セッションが無効な場合 */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    Activate: {
-      /**
-       * Format: email
-       * @description ユーザーのmアドレス
-       */
-      m_address?: string;
-      /** @description ユーザーのactivation token */
-      token: string;
-      /**
-       * @description パスワード
-       * @example carryL0v3
-       */
-      password: string;
+    schemas: {
+        Activate: {
+            /**
+             * Format: email
+             * @description ユーザーのmアドレス
+             */
+            m_address?: string;
+            /** @description ユーザーのactivation token */
+            token: string;
+            /**
+             * @description パスワード
+             * @example carryL0v3
+             */
+            password: string;
+        };
+        Login: {
+            /**
+             * @description mアドレス(新旧どちらも含む)
+             * @example johnson.p.5703@m.isct.ac.jp
+             */
+            m_address: string;
+            /**
+             * @description パスワード
+             * @example carryL0v3
+             */
+            password: string;
+        };
+        LoginSuccess: {
+            /**
+             * Format: jwt
+             * @description アクセストークン(jwt)
+             * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikd1eS1NYW51ZWwgZGUgSG9tZW0gQ2hyaXN0byIsImlhdCI6MTUxNjIzOTAyMn0.DVUM5s6qVNEg1YUycbacP82KhRnvvfS8kEecEXXZi5U
+             */
+            access_token: string;
+            /**
+             * Format: jwt
+             * @description リフレッシュトークン(jwt)
+             * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikd1eS1NYW51ZWwgZGUgSG9tZW0gQ2hyaXN0byIsImlhdCI6MTUxNjIzOTAyMn0.DVUM5s6qVNEg1YUycbacP82KhRnvvfS8kEecEXXZi5U
+             */
+            refresh_token: string;
+        };
+        Refresh: {
+            /**
+             * Format: jwt
+             * @description リフレッシュトークン
+             * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikd1eS1NYW51ZWwgZGUgSG9tZW0gQ2hyaXN0byIsImlhdCI6MTUxNjIzOTAyMn0.DVUM5s6qVNEg1YUycbacP82KhRnvvfS8kEecEXXZi5U
+             */
+            refresh_token?: string;
+        };
+        PasswordChange: {
+            /**
+             * Format: jwt
+             * @description アクセストークン
+             * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikd1eS1NYW51ZWwgZGUgSG9tZW0gQ2hyaXN0byIsImlhdCI6MTUxNjIzOTAyMn0.DVUM5s6qVNEg1YUycbacP82KhRnvvfS8kEecEXXZi5U
+             */
+            access_token: string;
+            /**
+             * @description 古いパスワード
+             * @example carryL0v3
+             */
+            old_password: string;
+            /**
+             * @description 新しいパスワード
+             * @example carry<3
+             */
+            new_password: string;
+        };
+        PasswordReset: {
+            /**
+             * Format: email
+             * @description メールアドレス
+             */
+            m_address: string;
+        };
+        PasswordResetConfirm: {
+            /** @description パスワードリセットトークン */
+            reset_token?: string;
+            /**
+             * @description 新しいパスワード
+             * @example carry<3
+             */
+            new_password?: string;
+        };
+        Revoke: {
+            /**
+             * Format: jwt
+             * @description リフレッシュトークン
+             * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikd1eS1NYW51ZWwgZGUgSG9tZW0gQ2hyaXN0byIsImlhdCI6MTUxNjIzOTAyMn0.DVUM5s6qVNEg1YUycbacP82KhRnvvfS8kEecEXXZi5U
+             */
+            refresh_token: string;
+        };
+        AdminRedirectPayload: {
+            /** @description code */
+            code: string;
+            /** @description state */
+            state: string;
+        };
     };
-    Login: {
-      /**
-       * @description mアドレス(新旧どちらも含む)
-       * @example johnson.p.5703@m.isct.ac.jp
-       */
-      m_address: string;
-      /**
-       * @description パスワード
-       * @example carryL0v3
-       */
-      password: string;
-    };
-    LoginSuccess: {
-      /**
-       * Format: jwt
-       * @description アクセストークン(jwt)
-       * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikd1eS1NYW51ZWwgZGUgSG9tZW0gQ2hyaXN0byIsImlhdCI6MTUxNjIzOTAyMn0.DVUM5s6qVNEg1YUycbacP82KhRnvvfS8kEecEXXZi5U
-       */
-      access_token: string;
-      /**
-       * Format: jwt
-       * @description リフレッシュトークン(jwt)
-       * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikd1eS1NYW51ZWwgZGUgSG9tZW0gQ2hyaXN0byIsImlhdCI6MTUxNjIzOTAyMn0.DVUM5s6qVNEg1YUycbacP82KhRnvvfS8kEecEXXZi5U
-       */
-      refresh_token: string;
-    };
-    Refresh: {
-      /**
-       * Format: jwt
-       * @description リフレッシュトークン
-       * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikd1eS1NYW51ZWwgZGUgSG9tZW0gQ2hyaXN0byIsImlhdCI6MTUxNjIzOTAyMn0.DVUM5s6qVNEg1YUycbacP82KhRnvvfS8kEecEXXZi5U
-       */
-      refresh_token?: string;
-    };
-    PasswordChange: {
-      /**
-       * Format: jwt
-       * @description アクセストークン
-       * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikd1eS1NYW51ZWwgZGUgSG9tZW0gQ2hyaXN0byIsImlhdCI6MTUxNjIzOTAyMn0.DVUM5s6qVNEg1YUycbacP82KhRnvvfS8kEecEXXZi5U
-       */
-      access_token: string;
-      /**
-       * @description 古いパスワード
-       * @example carryL0v3
-       */
-      old_password: string;
-      /**
-       * @description 新しいパスワード
-       * @example carry<3
-       */
-      new_password: string;
-    };
-    PasswordReset: {
-      /**
-       * Format: email
-       * @description メールアドレス
-       */
-      m_address: string;
-    };
-    PasswordResetConfirm: {
-      /** @description パスワードリセットトークン */
-      reset_token?: string;
-      /**
-       * @description 新しいパスワード
-       * @example carry<3
-       */
-      new_password?: string;
-    };
-    Revoke: {
-      /**
-       * Format: jwt
-       * @description リフレッシュトークン
-       * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikd1eS1NYW51ZWwgZGUgSG9tZW0gQ2hyaXN0byIsImlhdCI6MTUxNjIzOTAyMn0.DVUM5s6qVNEg1YUycbacP82KhRnvvfS8kEecEXXZi5U
-       */
-      refresh_token: string;
-    };
-    AdminRedirectPayload: {
-      /** @description code */
-      code: string;
-      /** @description state */
-      state: string;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export type operations = Record<string, never>;

--- a/libs/shared-types/src/plans_info_api_v1.d.ts
+++ b/libs/shared-types/src/plans_info_api_v1.d.ts
@@ -4,1152 +4,1097 @@
  */
 
 export interface paths {
-  '/plans': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 全ての企画情報を取得
-     * @description 工大祭の全ての企画情報を取得します。
-     */
-    get: {
-      parameters: {
-        query?: {
-          /** @description 企画タイプでフィルタリング（カンマ区切りで複数指定可） */
-          type?: ('booth' | 'general' | 'stage' | 'labo')[];
-          /** @description おすすめ企画でフィルタリング */
-          recommended?: boolean;
-          /** @description 子供向け企画でフィルタリング */
-          child_friendly?: boolean;
-          /** @description 研究室ツアー参加企画でフィルタリング */
-          lab_tour?: boolean;
-          /** @description スケジュールの表現方法。省略時はtrue。trueの場合：null→null、配列→全要素の最小start_timeと最大end_timeに結合した単一オブジェクト、文字列→文字列、オブジェクト→オブジェクト。falseの場合：null→[]、配列→そのまま、文字列→[文字列]、オブジェクト→[オブジェクト]。 */
-          combine_schedule?: boolean;
+    "/plans": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 企画情報のリスト */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              plans?: (
-                | components['schemas']['BoothPlanRead']
-                | components['schemas']['GeneralPlanRead']
-                | components['schemas']['StagePlanRead']
-                | components['schemas']['LaboPlanRead']
-              )[];
+        /**
+         * 全ての企画情報を取得
+         * @description 工大祭の全ての企画情報を取得します。
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 企画タイプでフィルタリング（カンマ区切りで複数指定可） */
+                    type?: ("booth" | "general" | "stage" | "labo")[];
+                    /** @description おすすめ企画でフィルタリング */
+                    recommended?: boolean;
+                    /** @description 子供向け企画でフィルタリング */
+                    child_friendly?: boolean;
+                    /** @description 研究室ツアー参加企画でフィルタリング */
+                    lab_tour?: boolean;
+                    /** @description スケジュールの表現方法。省略時はtrue。trueの場合：null→null、配列→全要素の最小start_timeと最大end_timeに結合した単一オブジェクト、文字列→文字列、オブジェクト→オブジェクト。falseの場合：null→[]、配列→そのまま、文字列→[文字列]、オブジェクト→[オブジェクト]。 */
+                    combine_schedule?: boolean;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
             };
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/plans/{planId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * 特定の企画情報を取得
-     * @description 指定されたIDの企画情報を取得します。
-     */
-    get: {
-      parameters: {
-        query?: {
-          /** @description スケジュールの表現方法。省略時はtrue。trueの場合：null→null、配列→全要素の最小start_timeと最大end_timeに結合した単一オブジェクト、文字列→文字列、オブジェクト→オブジェクト。falseの場合：null→[]、配列→そのまま、文字列→[文字列]、オブジェクト→[オブジェクト]。 */
-          combine_schedule?: boolean;
-        };
-        header?: never;
-        path: {
-          /** @description 企画ID */
-          planId: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 企画情報 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json':
-              | components['schemas']['BoothPlanRead']
-              | components['schemas']['GeneralPlanRead']
-              | components['schemas']['StagePlanRead']
-              | components['schemas']['LaboPlanRead'];
-          };
-        };
-        /** @description 企画が見つかりません */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/admin/plans/{planId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    /**
-     * 新しい企画を作成
-     * @description 指定されたIDで新しい企画を作成します。すでに同じIDの企画が存在する場合はconflictエラーを返します。
-     */
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 企画ID */
-          planId: string;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json':
-            | components['schemas']['BoothPlanCreate']
-            | components['schemas']['GeneralPlanCreate']
-            | components['schemas']['StagePlanCreate']
-            | components['schemas']['LaboPlanCreate'];
-        };
-      };
-      responses: {
-        /** @description 企画が正常に作成されました */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description リクエストが無効です */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
-        };
-        /** @description 指定されたIDの企画が既に存在します */
-        409: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
-        };
-      };
-    };
-    post?: never;
-    /**
-     * 企画を削除
-     * @description 指定されたIDの企画を削除します。
-     */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 企画ID */
-          planId: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 企画が正常に削除されました */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 企画が見つかりません */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    /**
-     * 企画情報を更新
-     * @description 指定されたIDの企画情報を更新します。企画が存在しない場合は404エラーを返します。
-     */
-    patch: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 企画ID */
-          planId: string;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json':
-            | components['schemas']['BoothPlanUpdate']
-            | components['schemas']['GeneralPlanUpdate']
-            | components['schemas']['StagePlanUpdate']
-            | components['schemas']['LaboPlanUpdate'];
-        };
-      };
-      responses: {
-        /** @description 企画が正常に更新されました */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description リクエストが無効です */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
-        };
-        /** @description 企画が見つかりません */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
-        };
-      };
-    };
-    trace?: never;
-  };
-  '/admin/plans:bulk': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * 企画の一括作成
-     * @description 指定されたIDの企画を複数まとめて作成します。
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            [key: string]: components['schemas']['BasePlanCreate'];
-          };
-        };
-      };
-      responses: {
-        /** @description 企画が正常に一括作成されました */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 一部の企画作成に失敗しました */
-        207: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @description 失敗したエントリーのエラー情報 */
-              errors?: (components['schemas']['Error'] & {
-                /** @description 失敗した企画のID */
-                plan_id: string;
-              })[];
+            requestBody?: never;
+            responses: {
+                /** @description 企画情報のリスト */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            plans?: (components["schemas"]["BoothPlanRead"] | components["schemas"]["GeneralPlanRead"] | components["schemas"]["StagePlanRead"] | components["schemas"]["LaboPlanRead"])[];
+                        };
+                    };
+                };
             };
-          };
         };
-        /** @description リクエストが無効です */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
-        };
-        /** @description 企画が見つかりません */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
-        };
-      };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    /**
-     * 企画の一括更新
-     * @description 指定されたIDの企画を複数まとめて更新します。存在しない企画IDは無視されます。
-     */
-    patch: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            [key: string]:
-              | components['schemas']['BoothPlanUpdate']
-              | components['schemas']['GeneralPlanUpdate']
-              | components['schemas']['StagePlanUpdate']
-              | components['schemas']['LaboPlanUpdate'];
-          };
+    "/plans/{planId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      responses: {
-        /** @description 企画が正常に一括更新されました */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 一部の企画更新に失敗しました */
-        207: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              /** @description 失敗したエントリーのエラー情報 */
-              errors?: (components['schemas']['Error'] & {
-                /** @description 失敗した企画のID */
-                plan_id: string;
-              })[];
+        /**
+         * 特定の企画情報を取得
+         * @description 指定されたIDの企画情報を取得します。
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description スケジュールの表現方法。省略時はtrue。trueの場合：null→null、配列→全要素の最小start_timeと最大end_timeに結合した単一オブジェクト、文字列→文字列、オブジェクト→オブジェクト。falseの場合：null→[]、配列→そのまま、文字列→[文字列]、オブジェクト→[オブジェクト]。 */
+                    combine_schedule?: boolean;
+                };
+                header?: never;
+                path: {
+                    /** @description 企画ID */
+                    planId: string;
+                };
+                cookie?: never;
             };
-          };
+            requestBody?: never;
+            responses: {
+                /** @description 企画情報 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BoothPlanRead"] | components["schemas"]["GeneralPlanRead"] | components["schemas"]["StagePlanRead"] | components["schemas"]["LaboPlanRead"];
+                    };
+                };
+                /** @description 企画が見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-        /** @description リクエストが無効です */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
-        };
-      };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    trace?: never;
-  };
-  '/plans/{planId}/details': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/admin/plans/{planId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * 新しい企画を作成
+         * @description 指定されたIDで新しい企画を作成します。すでに同じIDの企画が存在する場合はconflictエラーを返します。
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 企画ID */
+                    planId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["BoothPlanCreate"] | components["schemas"]["GeneralPlanCreate"] | components["schemas"]["StagePlanCreate"] | components["schemas"]["LaboPlanCreate"];
+                };
+            };
+            responses: {
+                /** @description 企画が正常に作成されました */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description リクエストが無効です */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description 指定されたIDの企画が既に存在します */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        /**
+         * 企画を削除
+         * @description 指定されたIDの企画を削除します。
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 企画ID */
+                    planId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 企画が正常に削除されました */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 企画が見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /**
+         * 企画情報を更新
+         * @description 指定されたIDの企画情報を更新します。企画が存在しない場合は404エラーを返します。
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 企画ID */
+                    planId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["BoothPlanUpdate"] | components["schemas"]["GeneralPlanUpdate"] | components["schemas"]["StagePlanUpdate"] | components["schemas"]["LaboPlanUpdate"];
+                };
+            };
+            responses: {
+                /** @description 企画が正常に更新されました */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description リクエストが無効です */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description 企画が見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        trace?: never;
     };
-    /**
-     * 企画の詳細情報を取得
-     * @description 指定されたIDの企画の詳細情報を取得します。
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 企画ID */
-          planId: string;
+    "/admin/plans:bulk": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 企画詳細情報 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ReadPlanDetails'];
-          };
+        get?: never;
+        put?: never;
+        /**
+         * 企画の一括作成
+         * @description 指定されたIDの企画を複数まとめて作成します。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        [key: string]: components["schemas"]["BasePlanCreate"];
+                    };
+                };
+            };
+            responses: {
+                /** @description 企画が正常に一括作成されました */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 一部の企画作成に失敗しました */
+                207: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @description 失敗したエントリーのエラー情報 */
+                            errors?: (components["schemas"]["Error"] & {
+                                /** @description 失敗した企画のID */
+                                plan_id: string;
+                            })[];
+                        };
+                    };
+                };
+                /** @description リクエストが無効です */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description 企画が見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-        /** @description 企画が見つかりません */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * 企画の一括更新
+         * @description 指定されたIDの企画を複数まとめて更新します。存在しない企画IDは無視されます。
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        [key: string]: components["schemas"]["BoothPlanUpdate"] | components["schemas"]["GeneralPlanUpdate"] | components["schemas"]["StagePlanUpdate"] | components["schemas"]["LaboPlanUpdate"];
+                    };
+                };
+            };
+            responses: {
+                /** @description 企画が正常に一括更新されました */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 一部の企画更新に失敗しました */
+                207: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @description 失敗したエントリーのエラー情報 */
+                            errors?: (components["schemas"]["Error"] & {
+                                /** @description 失敗した企画のID */
+                                plan_id: string;
+                            })[];
+                        };
+                    };
+                };
+                /** @description リクエストが無効です */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-      };
+        trace?: never;
     };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/admin/plans/{planId}/details': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/plans/{planId}/details": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 企画の詳細情報を取得
+         * @description 指定されたIDの企画の詳細情報を取得します。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 企画ID */
+                    planId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 企画詳細情報 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReadPlanDetails"];
+                    };
+                };
+                /** @description 企画が見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 企画の詳細情報を取得（管理）
-     * @description 指定されたIDの企画の詳細情報を取得します（管理用）。
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 企画ID */
-          planId: string;
+    "/admin/plans/{planId}/details": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description 企画詳細情報 */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ReadPlanDetails'];
-          };
+        /**
+         * 企画の詳細情報を取得（管理）
+         * @description 指定されたIDの企画の詳細情報を取得します（管理用）。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 企画ID */
+                    planId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 企画詳細情報 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReadPlanDetails"];
+                    };
+                };
+                /** @description 企画が見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-        /** @description 企画が見つかりません */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
+        /**
+         * 企画の詳細情報を作成・更新
+         * @description 指定されたIDの企画の詳細情報を作成または完全に更新します。
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 企画ID */
+                    planId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreatePlanDetails"];
+                };
+            };
+            responses: {
+                /** @description 詳細情報が正常に作成・更新されました */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description リクエストが無効です */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description 企画が見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-      };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 企画の詳細情報を作成・更新
-     * @description 指定されたIDの企画の詳細情報を作成または完全に更新します。
-     */
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 企画ID */
-          planId: string;
+    "/plans/{planId}/icon": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['CreatePlanDetails'];
+        /**
+         * 企画のアイコンを取得
+         * @description 指定されたIDの企画のアイコン画像を直接ダウンロードします
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 企画ID */
+                    planId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description アイコン画像ファイル */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "image/png": string;
+                        "image/jpeg": string;
+                        "image/gif": string;
+                        "image/webp": string;
+                    };
+                };
+                /** @description 企画またはアイコンが見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-      };
-      responses: {
-        /** @description 詳細情報が正常に作成・更新されました */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description リクエストが無効です */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
-        };
-        /** @description 企画が見つかりません */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
-        };
-      };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/plans/{planId}/icon': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/admin/plans/{planId}/icon": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * 企画のアイコンをアップロード
+         * @description 指定されたIDの企画のアイコン画像をアップロードします．アップロード時にアイコン画像が最適化されます．
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 企画ID */
+                    planId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "image/png": string;
+                    "image/jpeg": string;
+                    "image/gif": string;
+                    "image/webp": string;
+                };
+            };
+            responses: {
+                /** @description アイコンが正常にアップロードされました */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 画像最適化に失敗しました */
+                502: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 企画のアイコンを取得
-     * @description 指定されたIDの企画のアイコン画像を直接ダウンロードします
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 企画ID */
-          planId: string;
+    "/admin/plans/{planId}/icon:import": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description アイコン画像ファイル */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'image/png': string;
-            'image/jpeg': string;
-            'image/gif': string;
-            'image/webp': string;
-          };
+        get?: never;
+        put?: never;
+        /**
+         * URLからアイコンをインポート
+         * @description 指定されたURLからアイコンをダウンロードして企画のアイコンとして設定します
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 企画の一意識別子 */
+                    planId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /**
+                         * Format: uri
+                         * @description インポートするアイコンのURL
+                         * @example https://example.com/icon.png
+                         */
+                        url: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description アイコンが正常にインポートされました */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 無効なリクエスト（URLが無効など） */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description アイコンのダウンロードまたは処理に失敗しました */
+                502: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
         };
-        /** @description 企画またはアイコンが見つかりません */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/admin/plans/{planId}/icon': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    /**
-     * 企画のアイコンをアップロード
-     * @description 指定されたIDの企画のアイコン画像をアップロードします．アップロード時にアイコン画像が最適化されます．
-     */
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 企画ID */
-          planId: string;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'image/png': string;
-          'image/jpeg': string;
-          'image/gif': string;
-          'image/webp': string;
-        };
-      };
-      responses: {
-        /** @description アイコンが正常にアップロードされました */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 画像最適化に失敗しました */
-        502: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
-        };
-      };
-    };
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/admin/plans/{planId}/icon:import': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * URLからアイコンをインポート
-     * @description 指定されたURLからアイコンをダウンロードして企画のアイコンとして設定します
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description 企画の一意識別子 */
-          planId: string;
-        };
-        cookie?: never;
-      };
-      requestBody: {
-        content: {
-          'application/json': {
-            /**
-             * Format: uri
-             * @description インポートするアイコンのURL
-             * @example https://example.com/icon.png
-             */
-            url: string;
-          };
-        };
-      };
-      responses: {
-        /** @description アイコンが正常にインポートされました */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description 無効なリクエスト（URLが無効など） */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
-        };
-        /** @description アイコンのダウンロードまたは処理に失敗しました */
-        502: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Error'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    IndoorLocation: {
-      /**
-       * @description 企画実施場所が屋内であることを示す
-       * @enum {string}
-       */
-      type: 'indoor';
-      /** @description 建物名 */
-      building: string;
-      /** @description 部屋名 */
-      room: string;
-    };
-    OutdoorLocation: {
-      /**
-       * @description 企画実施場所が屋外であることを示す
-       * @enum {string}
-       */
-      type: 'outdoor';
-      /** @description 企画実施場所の名称 */
-      name: string;
-    };
-    /**
-     * Format: enum
-     * @description 模擬店企画のカテゴリ
-     *     - `main_rice` - ごはん系
-     *     - `main_noodle_flour` - 麺・粉もの系
-     *     - `main_skewer_grill` - 串・焼き物系
-     *     - `main_hot_snack` - ホットフード・軽食系
-     *     - `main_soup` - スープ系
-     *     - `main_world_street` - 世界の屋台フード
-     *     - `sweet_japanese` - 和スイーツ
-     *     - `sweet_western` - 洋スイーツ
-     *     - `sweet_cold` - 冷たいスイーツ
-     *     - `sweet_snack` - スナックスイーツ
-     *     - `sweet_drink` - 飲むスイーツ（デザートドリンク）
-     *     - `sweet_world` - 世界のスイーツ・甘味系屋台フード
-     *     - `drink` - ドリンク系
-     * @enum {string}
-     */
-    BoothPlanCategory:
-      | 'main_rice'
-      | 'main_noodle_flour'
-      | 'main_skewer_grill'
-      | 'main_hot_snack'
-      | 'main_soup'
-      | 'main_world_street'
-      | 'sweet_japanese'
-      | 'sweet_western'
-      | 'sweet_cold'
-      | 'sweet_snack'
-      | 'sweet_drink'
-      | 'sweet_world'
-      | 'drink';
-    /**
-     * Format: enum
-     * @description 一般企画のカテゴリ
-     *     - `play` - 遊び・体験
-     *     - `display` - 展示
-     *     - `performance` - パフォーマンス
-     *     - `cafe` - カフェ
-     *     - `rest` - 一休み
-     *     - `presentation`
-     * @enum {string}
-     */
-    GeneralPlanCategory:
-      | 'play'
-      | 'display'
-      | 'performance'
-      | 'cafe'
-      | 'rest'
-      | 'presentation';
-    DaySchedule: {
-      /**
-       * @description 企画開始時間（HH:mm形式）
-       * @example 10:00
-       */
-      start_time: string;
-      /**
-       * @description 企画終了時間（HH:mm形式）
-       * @example 17:00
-       */
-      end_time: string;
-      location?:
-        | (
-            | components['schemas']['IndoorLocation']
-            | components['schemas']['OutdoorLocation']
-          )
-        | null;
-    };
-    /** @description 企画のスケジュール（作成用） */
-    ScheduleCreate: {
-      day1?: components['schemas']['DaySchedule'] | null;
-      day2?: components['schemas']['DaySchedule'] | null;
-    };
-    /** @description 企画のスケジュール（読み取り用） */
-    ScheduleRead: {
-      day1?: components['schemas']['DaySchedule'] | null;
-      day2?: components['schemas']['DaySchedule'] | null;
-    };
-    /** @description 企画のスケジュール（更新用） */
-    ScheduleUpdate: {
-      day1?: components['schemas']['DaySchedule'] | null;
-      day2?: components['schemas']['DaySchedule'] | null;
-    };
-    BasePlanRead: {
-      /** @description 企画の一意識別子 */
-      id: string;
-      /** @description 企画のタイプ */
-      type: string;
-      /** @description 団体名（参加申請時のものを掲載、変更原則なし） */
-      organization_name: string;
-      /** @description 企画名（企画内容申請時のものを掲載、変更原則なし） */
-      plan_name: string;
-      /** @description 企画内容紹介文 */
-      description: string;
-      /** @description 子供向け企画か否か */
-      is_child_friendly: boolean;
-      /** @description おすすめ企画か否か */
-      is_recommended: boolean;
-      schedule: components['schemas']['ScheduleRead'];
-      /** @description 企画実施場所一覧 */
-      location: (
-        | components['schemas']['IndoorLocation']
-        | components['schemas']['OutdoorLocation']
-      )[];
-      /** @description 企画の緯度経度座標 */
-      coordinates?: {
+    schemas: {
+        IndoorLocation: {
+            /**
+             * @description 企画実施場所が屋内であることを示す
+             * @enum {string}
+             */
+            type: "indoor";
+            /** @description 建物名 */
+            building: string;
+            /** @description 部屋名 */
+            room: string;
+        };
+        OutdoorLocation: {
+            /**
+             * @description 企画実施場所が屋外であることを示す
+             * @enum {string}
+             */
+            type: "outdoor";
+            /** @description 企画実施場所の名称 */
+            name: string;
+        };
         /**
-         * Format: float
-         * @description 緯度
+         * Format: enum
+         * @description 模擬店企画のカテゴリ
+         *     - `main_rice` - ごはん系
+         *     - `main_noodle_flour` - 麺・粉もの系
+         *     - `main_skewer_grill` - 串・焼き物系
+         *     - `main_hot_snack` - ホットフード・軽食系
+         *     - `main_soup` - スープ系
+         *     - `main_world_street` - 世界の屋台フード
+         *     - `sweet_japanese` - 和スイーツ
+         *     - `sweet_western` - 洋スイーツ
+         *     - `sweet_cold` - 冷たいスイーツ
+         *     - `sweet_snack` - スナックスイーツ
+         *     - `sweet_drink` - 飲むスイーツ（デザートドリンク）
+         *     - `sweet_world` - 世界のスイーツ・甘味系屋台フード
+         *     - `drink` - ドリンク系
+         * @enum {string}
          */
-        latitude: number;
+        BoothPlanCategory: "main_rice" | "main_noodle_flour" | "main_skewer_grill" | "main_hot_snack" | "main_soup" | "main_world_street" | "sweet_japanese" | "sweet_western" | "sweet_cold" | "sweet_snack" | "sweet_drink" | "sweet_world" | "drink";
         /**
-         * Format: float
-         * @description 経度
+         * Format: enum
+         * @description 一般企画のカテゴリ
+         *     - `play` - 遊び・体験
+         *     - `display` - 展示
+         *     - `performance` - パフォーマンス
+         *     - `cafe` - カフェ
+         *     - `rest` - 一休み
+         *     - `presentation`
+         * @enum {string}
          */
-        longitude: number;
-      } | null;
-    };
-    BasePlanCreate: {
-      /** @description 企画のタイプ */
-      type: string;
-      /** @description 団体名（参加申請時のものを掲載、変更原則なし） */
-      organization_name: string;
-      /** @description 企画名（企画内容申請時のものを掲載、変更原則なし） */
-      plan_name: string;
-      /** @description 企画内容紹介文 */
-      description: string;
-      /** @description 子供向け企画か否か */
-      is_child_friendly: boolean;
-      /** @description おすすめ企画か否か */
-      is_recommended: boolean;
-      schedule: components['schemas']['ScheduleCreate'];
-      /** @description 企画実施場所一覧 */
-      location: (
-        | components['schemas']['IndoorLocation']
-        | components['schemas']['OutdoorLocation']
-      )[];
-      /** @description 企画の緯度経度座標 */
-      coordinates?: {
+        GeneralPlanCategory: "play" | "display" | "performance" | "cafe" | "rest" | "presentation";
+        DaySchedule: {
+            /**
+             * @description 企画開始時間（HH:mm形式）
+             * @example 10:00
+             */
+            start_time: string;
+            /**
+             * @description 企画終了時間（HH:mm形式）
+             * @example 17:00
+             */
+            end_time: string;
+            location?: (components["schemas"]["IndoorLocation"] | components["schemas"]["OutdoorLocation"]) | null;
+        };
+        /** @description 企画のスケジュール（作成用） */
+        ScheduleCreate: {
+            day1?: components["schemas"]["DaySchedule"] | null;
+            day2?: components["schemas"]["DaySchedule"] | null;
+        };
+        /** @description 企画のスケジュール（読み取り用） */
+        ScheduleRead: {
+            day1?: components["schemas"]["DaySchedule"] | null;
+            day2?: components["schemas"]["DaySchedule"] | null;
+        };
+        /** @description 企画のスケジュール（更新用） */
+        ScheduleUpdate: {
+            day1?: components["schemas"]["DaySchedule"] | null;
+            day2?: components["schemas"]["DaySchedule"] | null;
+        };
+        BasePlanRead: {
+            /** @description 企画の一意識別子 */
+            id: string;
+            /** @description 企画のタイプ */
+            type: string;
+            /** @description 団体名（参加申請時のものを掲載、変更原則なし） */
+            organization_name: string;
+            /** @description 企画名（企画内容申請時のものを掲載、変更原則なし） */
+            plan_name: string;
+            /** @description 企画内容紹介文 */
+            description: string;
+            /** @description 子供向け企画か否か */
+            is_child_friendly: boolean;
+            /** @description おすすめ企画か否か */
+            is_recommended: boolean;
+            schedule: components["schemas"]["ScheduleRead"];
+            /** @description 企画実施場所一覧 */
+            location: (components["schemas"]["IndoorLocation"] | components["schemas"]["OutdoorLocation"])[];
+            /** @description 企画の緯度経度座標 */
+            coordinates?: {
+                /**
+                 * Format: float
+                 * @description 緯度
+                 */
+                latitude: number;
+                /**
+                 * Format: float
+                 * @description 経度
+                 */
+                longitude: number;
+            } | null;
+        };
+        BasePlanCreate: {
+            /** @description 企画のタイプ */
+            type: string;
+            /** @description 団体名（参加申請時のものを掲載、変更原則なし） */
+            organization_name: string;
+            /** @description 企画名（企画内容申請時のものを掲載、変更原則なし） */
+            plan_name: string;
+            /** @description 企画内容紹介文 */
+            description: string;
+            /** @description 子供向け企画か否か */
+            is_child_friendly: boolean;
+            /** @description おすすめ企画か否か */
+            is_recommended: boolean;
+            schedule: components["schemas"]["ScheduleCreate"];
+            /** @description 企画実施場所一覧 */
+            location: (components["schemas"]["IndoorLocation"] | components["schemas"]["OutdoorLocation"])[];
+            /** @description 企画の緯度経度座標 */
+            coordinates?: {
+                /**
+                 * Format: float
+                 * @description 緯度
+                 */
+                latitude: number;
+                /**
+                 * Format: float
+                 * @description 経度
+                 */
+                longitude: number;
+            } | null;
+        };
+        BasePlanUpdate: {
+            /** @description 団体名（参加申請時のものを掲載、変更原則なし） */
+            organization_name?: string;
+            /** @description 企画名（企画内容申請時のものを掲載、変更原則なし） */
+            plan_name?: string;
+            /** @description 企画内容紹介文 */
+            description?: string;
+            /** @description 子供向け企画か否か */
+            is_child_friendly?: boolean;
+            /** @description おすすめ企画か否か */
+            is_recommended?: boolean;
+            schedule?: components["schemas"]["ScheduleUpdate"];
+            /** @description 企画実施場所一覧 */
+            location?: (components["schemas"]["IndoorLocation"] | components["schemas"]["OutdoorLocation"])[];
+            /** @description 企画の緯度経度座標 */
+            coordinates?: {
+                /**
+                 * Format: float
+                 * @description 緯度
+                 */
+                latitude: number;
+                /**
+                 * Format: float
+                 * @description 経度
+                 */
+                longitude: number;
+            } | null;
+        };
+        /** @description 当日販売される商品情報（作成用） */
+        ProductsCreate: {
+            /** @description 商品の一覧 */
+            items: {
+                /** @description 商品名 */
+                name: string;
+                /** @description 値段 */
+                price: number | null;
+                /** @description トッピングやフレーバーなどのオプション */
+                options: {
+                    /** @description 商品名 */
+                    name: string;
+                    /** @description 値段 */
+                    price: number | null;
+                }[];
+            }[];
+            /** @description 商品全体の説明文 */
+            description: string;
+        };
+        /** @description 当日販売される商品情報（読み取り用） */
+        ProductsRead: {
+            /** @description 商品の一覧 */
+            items: {
+                /** @description 商品名 */
+                name: string;
+                /** @description 値段 */
+                price: number | null;
+                /** @description トッピングやフレーバーなどのオプション */
+                options: {
+                    /** @description 商品名 */
+                    name: string;
+                    /** @description 値段 */
+                    price: number | null;
+                }[];
+            }[];
+            /** @description 商品全体の説明文 */
+            description: string;
+        };
+        /** @description 当日販売される商品情報（更新用） */
+        ProductsUpdate: {
+            /** @description 商品の一覧 */
+            items?: {
+                /** @description 商品名 */
+                name?: string;
+                /** @description 値段 */
+                price?: number | null;
+                /** @description トッピングやフレーバーなどのオプション */
+                options?: {
+                    /** @description 商品名 */
+                    name?: string;
+                    /** @description 値段 */
+                    price?: number | null;
+                }[];
+            }[];
+            /** @description 商品全体の説明文 */
+            description?: string;
+        };
+        CreatePlanDetails: {
+            product?: components["schemas"]["ProductsCreate"];
+            /** @description 追加情報（マークダウン形式） */
+            additional_info?: string | null;
+        };
+        ReadPlanDetails: {
+            product?: components["schemas"]["ProductsRead"];
+            /** @description 追加情報（マークダウン形式） */
+            additional_info?: string | null;
+        };
+        UpdatePlanDetails: {
+            product?: components["schemas"]["ProductsUpdate"];
+            /** @description 追加情報（マークダウン形式） */
+            additional_info?: string | null;
+        };
+        BoothPlanRead: components["schemas"]["BasePlanRead"] & {
+            /** @description 模擬店企画ID（M-000形式） */
+            id?: string;
+            /** @enum {string} */
+            type: "booth";
+            categories: components["schemas"]["BoothPlanCategory"][];
+        };
+        BoothPlanCreate: components["schemas"]["BasePlanCreate"] & {
+            /** @enum {string} */
+            type: "booth";
+            categories: components["schemas"]["BoothPlanCategory"][];
+        };
+        BoothPlanUpdate: components["schemas"]["BasePlanUpdate"] & {
+            categories?: components["schemas"]["BoothPlanCategory"][];
+        };
         /**
-         * Format: float
-         * @description 緯度
+         * @example {
+         *       "id": "I-001",
+         *       "type": "general",
+         *       "categories": [
+         *         "play"
+         *       ],
+         *       "organization_name": "ゲーム制作サークル",
+         *       "plan_name": "オリジナルゲーム体験会",
+         *       "description": "サークルメンバーが制作したオリジナルゲームを体験できます。",
+         *       "is_child_friendly": true,
+         *       "is_recommended": true,
+         *       "schedule": {
+         *         "day1": {
+         *           "start_time": "10:00",
+         *           "end_time": "17:00"
+         *         }
+         *       },
+         *       "location": [
+         *         {
+         *           "type": "indoor",
+         *           "building": "第二校舎",
+         *           "room": "2F 201教室"
+         *         }
+         *       ]
+         *     }
          */
-        latitude: number;
+        GeneralPlanRead: components["schemas"]["BasePlanRead"] & {
+            /** @description 一般企画ID（I-000形式） */
+            id?: string;
+            /** @enum {string} */
+            type: "general";
+            categories: components["schemas"]["GeneralPlanCategory"][];
+        };
+        GeneralPlanCreate: components["schemas"]["BasePlanCreate"] & {
+            /** @enum {string} */
+            type: "general";
+            categories: components["schemas"]["GeneralPlanCategory"][];
+        };
+        GeneralPlanUpdate: components["schemas"]["BasePlanUpdate"] & {
+            categories?: components["schemas"]["GeneralPlanCategory"][];
+        };
         /**
-         * Format: float
-         * @description 経度
+         * @example {
+         *       "id": "S-001",
+         *       "type": "stage",
+         *       "organization_name": "軽音楽部",
+         *       "plan_name": "アコースティックライブ",
+         *       "description": "人気曲のカバーと部員によるオリジナル曲の演奏をお届けします。",
+         *       "is_child_friendly": true,
+         *       "is_recommended": true,
+         *       "schedule": {
+         *         "day1": {
+         *           "start_time": "13:00",
+         *           "end_time": "14:00"
+         *         }
+         *       },
+         *       "location": [
+         *         {
+         *           "type": "outdoor",
+         *           "name": "中央ステージ"
+         *         }
+         *       ]
+         *     }
          */
-        longitude: number;
-      } | null;
-    };
-    BasePlanUpdate: {
-      /** @description 団体名（参加申請時のものを掲載、変更原則なし） */
-      organization_name?: string;
-      /** @description 企画名（企画内容申請時のものを掲載、変更原則なし） */
-      plan_name?: string;
-      /** @description 企画内容紹介文 */
-      description?: string;
-      /** @description 子供向け企画か否か */
-      is_child_friendly?: boolean;
-      /** @description おすすめ企画か否か */
-      is_recommended?: boolean;
-      schedule?: components['schemas']['ScheduleUpdate'];
-      /** @description 企画実施場所一覧 */
-      location?: (
-        | components['schemas']['IndoorLocation']
-        | components['schemas']['OutdoorLocation']
-      )[];
-      /** @description 企画の緯度経度座標 */
-      coordinates?: {
+        StagePlanRead: components["schemas"]["BasePlanRead"] & {
+            /** @description ステージ企画ID（S-000形式） */
+            id?: string;
+            /** @enum {string} */
+            type: "stage";
+        };
+        StagePlanCreate: components["schemas"]["BasePlanCreate"] & {
+            /** @enum {string} */
+            type: "stage";
+        };
+        StagePlanUpdate: components["schemas"]["BasePlanUpdate"] & Record<string, never>;
         /**
-         * Format: float
-         * @description 緯度
+         * @example {
+         *       "id": "L-001",
+         *       "type": "labo",
+         *       "organization_name": "ロボット工学研究室",
+         *       "plan_name": "ロボットプログラミング体験",
+         *       "description": "最新のロボット技術を体験し、簡単なプログラミングを学べます。",
+         *       "is_child_friendly": true,
+         *       "is_recommended": true,
+         *       "is_lab_tour": true,
+         *       "schedule": {
+         *         "day1": {
+         *           "start_time": "10:00",
+         *           "end_time": "16:00"
+         *         }
+         *       },
+         *       "location": [
+         *         {
+         *           "type": "indoor",
+         *           "building": "工学部棟",
+         *           "room": "3F 305研究室"
+         *         }
+         *       ]
+         *     }
          */
-        latitude: number;
-        /**
-         * Format: float
-         * @description 経度
-         */
-        longitude: number;
-      } | null;
+        LaboPlanRead: components["schemas"]["BasePlanRead"] & {
+            /** @description 研究室企画ID（L-000形式） */
+            id?: string;
+            /** @enum {string} */
+            type: "labo";
+            /** @description 研究室ツアー参加企画か否か */
+            is_lab_tour: boolean;
+        };
+        LaboPlanCreate: components["schemas"]["BasePlanCreate"] & {
+            /** @enum {string} */
+            type: "labo";
+            /** @description 研究室ツアー参加企画か否か */
+            is_lab_tour: boolean;
+        };
+        LaboPlanUpdate: components["schemas"]["BasePlanUpdate"] & {
+            /** @description 研究室ツアー参加企画か否か */
+            is_lab_tour?: boolean;
+        };
+        Error: {
+            /** Format: int32 */
+            code: number;
+            message: string;
+        };
     };
-    /** @description 当日販売される商品情報（作成用） */
-    ProductsCreate: {
-      /** @description 商品の一覧 */
-      items: {
-        /** @description 商品名 */
-        name: string;
-        /** @description 値段 */
-        price: number | null;
-        /** @description トッピングやフレーバーなどのオプション */
-        options: {
-          /** @description 商品名 */
-          name: string;
-          /** @description 値段 */
-          price: number | null;
-        }[];
-      }[];
-      /** @description 商品全体の説明文 */
-      description: string;
-    };
-    /** @description 当日販売される商品情報（読み取り用） */
-    ProductsRead: {
-      /** @description 商品の一覧 */
-      items: {
-        /** @description 商品名 */
-        name: string;
-        /** @description 値段 */
-        price: number | null;
-        /** @description トッピングやフレーバーなどのオプション */
-        options: {
-          /** @description 商品名 */
-          name: string;
-          /** @description 値段 */
-          price: number | null;
-        }[];
-      }[];
-      /** @description 商品全体の説明文 */
-      description: string;
-    };
-    /** @description 当日販売される商品情報（更新用） */
-    ProductsUpdate: {
-      /** @description 商品の一覧 */
-      items?: {
-        /** @description 商品名 */
-        name?: string;
-        /** @description 値段 */
-        price?: number | null;
-        /** @description トッピングやフレーバーなどのオプション */
-        options?: {
-          /** @description 商品名 */
-          name?: string;
-          /** @description 値段 */
-          price?: number | null;
-        }[];
-      }[];
-      /** @description 商品全体の説明文 */
-      description?: string;
-    };
-    CreatePlanDetails: {
-      product?: components['schemas']['ProductsCreate'];
-      /** @description 追加情報（マークダウン形式） */
-      additional_info?: string | null;
-    };
-    ReadPlanDetails: {
-      product?: components['schemas']['ProductsRead'];
-      /** @description 追加情報（マークダウン形式） */
-      additional_info?: string | null;
-    };
-    UpdatePlanDetails: {
-      product?: components['schemas']['ProductsUpdate'];
-      /** @description 追加情報（マークダウン形式） */
-      additional_info?: string | null;
-    };
-    BoothPlanRead: components['schemas']['BasePlanRead'] & {
-      /** @description 模擬店企画ID（M-000形式） */
-      id?: string;
-      /** @enum {string} */
-      type: 'booth';
-      categories: components['schemas']['BoothPlanCategory'][];
-    };
-    BoothPlanCreate: components['schemas']['BasePlanCreate'] & {
-      /** @enum {string} */
-      type: 'booth';
-      categories: components['schemas']['BoothPlanCategory'][];
-    };
-    BoothPlanUpdate: components['schemas']['BasePlanUpdate'] & {
-      categories?: components['schemas']['BoothPlanCategory'][];
-    };
-    /**
-     * @example {
-     *       "id": "I-001",
-     *       "type": "general",
-     *       "categories": [
-     *         "play"
-     *       ],
-     *       "organization_name": "ゲーム制作サークル",
-     *       "plan_name": "オリジナルゲーム体験会",
-     *       "description": "サークルメンバーが制作したオリジナルゲームを体験できます。",
-     *       "is_child_friendly": true,
-     *       "is_recommended": true,
-     *       "schedule": {
-     *         "day1": {
-     *           "start_time": "10:00",
-     *           "end_time": "17:00"
-     *         }
-     *       },
-     *       "location": [
-     *         {
-     *           "type": "indoor",
-     *           "building": "第二校舎",
-     *           "room": "2F 201教室"
-     *         }
-     *       ]
-     *     }
-     */
-    GeneralPlanRead: components['schemas']['BasePlanRead'] & {
-      /** @description 一般企画ID（I-000形式） */
-      id?: string;
-      /** @enum {string} */
-      type: 'general';
-      categories: components['schemas']['GeneralPlanCategory'][];
-    };
-    GeneralPlanCreate: components['schemas']['BasePlanCreate'] & {
-      /** @enum {string} */
-      type: 'general';
-      categories: components['schemas']['GeneralPlanCategory'][];
-    };
-    GeneralPlanUpdate: components['schemas']['BasePlanUpdate'] & {
-      categories?: components['schemas']['GeneralPlanCategory'][];
-    };
-    /**
-     * @example {
-     *       "id": "S-001",
-     *       "type": "stage",
-     *       "organization_name": "軽音楽部",
-     *       "plan_name": "アコースティックライブ",
-     *       "description": "人気曲のカバーと部員によるオリジナル曲の演奏をお届けします。",
-     *       "is_child_friendly": true,
-     *       "is_recommended": true,
-     *       "schedule": {
-     *         "day1": {
-     *           "start_time": "13:00",
-     *           "end_time": "14:00"
-     *         }
-     *       },
-     *       "location": [
-     *         {
-     *           "type": "outdoor",
-     *           "name": "中央ステージ"
-     *         }
-     *       ]
-     *     }
-     */
-    StagePlanRead: components['schemas']['BasePlanRead'] & {
-      /** @description ステージ企画ID（S-000形式） */
-      id?: string;
-      /** @enum {string} */
-      type: 'stage';
-    };
-    StagePlanCreate: components['schemas']['BasePlanCreate'] & {
-      /** @enum {string} */
-      type: 'stage';
-    };
-    StagePlanUpdate: components['schemas']['BasePlanUpdate'] &
-      Record<string, never>;
-    /**
-     * @example {
-     *       "id": "L-001",
-     *       "type": "labo",
-     *       "organization_name": "ロボット工学研究室",
-     *       "plan_name": "ロボットプログラミング体験",
-     *       "description": "最新のロボット技術を体験し、簡単なプログラミングを学べます。",
-     *       "is_child_friendly": true,
-     *       "is_recommended": true,
-     *       "is_lab_tour": true,
-     *       "schedule": {
-     *         "day1": {
-     *           "start_time": "10:00",
-     *           "end_time": "16:00"
-     *         }
-     *       },
-     *       "location": [
-     *         {
-     *           "type": "indoor",
-     *           "building": "工学部棟",
-     *           "room": "3F 305研究室"
-     *         }
-     *       ]
-     *     }
-     */
-    LaboPlanRead: components['schemas']['BasePlanRead'] & {
-      /** @description 研究室企画ID（L-000形式） */
-      id?: string;
-      /** @enum {string} */
-      type: 'labo';
-      /** @description 研究室ツアー参加企画か否か */
-      is_lab_tour: boolean;
-    };
-    LaboPlanCreate: components['schemas']['BasePlanCreate'] & {
-      /** @enum {string} */
-      type: 'labo';
-      /** @description 研究室ツアー参加企画か否か */
-      is_lab_tour: boolean;
-    };
-    LaboPlanUpdate: components['schemas']['BasePlanUpdate'] & {
-      /** @description 研究室ツアー参加企画か否か */
-      is_lab_tour?: boolean;
-    };
-    Error: {
-      /** Format: int32 */
-      code: number;
-      message: string;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export type operations = Record<string, never>;

--- a/project.json
+++ b/project.json
@@ -5,7 +5,7 @@
     "dev": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "nx run-many --target dev -p backend portal admin join --parallel & caddy run --config dev/Caddyfile --adapter caddyfile"
+        "command": "nx run-many --target dev -p backend portal admin join --parallel=4 & caddy run --config dev/Caddyfile --adapter caddyfile"
       }
     },
     "dev-proxy": {


### PR DESCRIPTION
## Summary

- Add environment-specific frontend build targets for `portal`, `admin`, and `join`.
- Add `deploy:production` targets that run the production build before `wrangler deploy`.
- Add and adjust Wrangler configuration for the frontend apps.
- Include generated shared API type updates already present on the branch.

## Validation

- Confirmed the web app `project.json` files parse and expose `build:development`, `build:production`, and `deploy:production` without the old `build` target.
- Confirmed Astro recognizes `astro build --mode production`.

## Notes

- A local `join` production build reached static route generation, then failed because this environment could not resolve `portal.koudaisai.jp` during fetch.