### PR TITLE
fix: auth_v2 — serialize refresh requests & restore rate limiting

### DIFF
--- a/apps/backend/src/routes/auth_v2.rs
+++ b/apps/backend/src/routes/auth_v2.rs
@@ -15,10 +15,13 @@ use crate::infra::s3_object_storage::S3ObjectStorage;
 use crate::infra::sendgrid_email::SendgridEmail;
 use crate::infra::sqlite::SqliteApplication;
 use crate::util::oidc::OIDCClient;
+use axum::http::Method;
+use axum_gcra::{RateLimitLayer, gcra::Quota, real_ip::RealIp};
 use jsonwebtoken::DecodingKey;
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::Mutex;
 use utoipa_axum::router::OpenApiRouter;
 use utoipa_axum::routes;
@@ -84,4 +87,20 @@ pub fn router() -> OpenApiRouter<AuthV2State> {
         .routes(routes!(handlers::password_reset_confirm))
         .routes(routes!(admin::admin_login))
         .routes(routes!(admin::admin_redirect))
+        .route_layer(
+            RateLimitLayer::<RealIp>::builder()
+                .with_routes([
+                    ((Method::POST, "/login"), Quota::simple(Duration::from_secs(3))),
+                    ((Method::POST, "/activate"), Quota::simple(Duration::from_secs(3))),
+                    (
+                        (Method::POST, "/password/reset"),
+                        Quota::simple(Duration::from_secs(10)),
+                    ),
+                    (
+                        (Method::POST, "/password/reset/confirm"),
+                        Quota::simple(Duration::from_secs(3)),
+                    ),
+                ])
+                .default_handle_error(),
+        )
 }

--- a/libs/shared-auth-members/src/auth.ts
+++ b/libs/shared-auth-members/src/auth.ts
@@ -2,6 +2,7 @@ import { AuthFetchClient, decodeAccessToken } from '@koudaisai/shared-auth';
 import type { Middleware } from 'openapi-fetch';
 
 const ACCESS_TOKEN_KEY = 'exhibitor_access_token';
+let refreshPromise: Promise<{ access_token: string } | undefined> | undefined;
 // リフレッシュトークンは HttpOnly Cookie(dev: `refresh_token` / prod: `__Host-refresh_token`)で
 // 配送される。JS からは読めないため localStorage には一切保持しない。
 
@@ -37,6 +38,17 @@ export const getTokensMembers = async (fetchClient: AuthFetchClient) => {
   //期限切れ or 不在 -> リフレッシュトークン Cookie で再発行を試みる。
   //Cookie は HttpOnly のため明示送信できない。client の credentials:'include' で自動送出される。
   //サーバはリクエストボディを取らず、Cookie のみから回転する。
+  //リフレッシュトークンは回転式で再利用を検知するとセッションファミリが失効するため、
+  //同時に複数の API リクエストが期限切れを検知しても 1 回だけ /refresh する。
+  refreshPromise ??= refreshTokensMembers(fetchClient);
+  try {
+    return await refreshPromise;
+  } finally {
+    refreshPromise = undefined;
+  }
+};
+
+const refreshTokensMembers = async (fetchClient: AuthFetchClient) => {
   const { data } = await fetchClient.POST('/refresh', {});
 
   if (data) {


### PR DESCRIPTION
### Motivation

- Prevent accidental user logout when multiple parallel requests attempt refresh after access-token expiry by ensuring only one `/refresh` call rotates refresh tokens per browser session. 
- Reapply per-IP throttling to public unauthenticated auth endpoints to stop credential brute-force and resource-exhaustion attacks that were accidentally removed during the router migration.

### Description

- Added a shared in-flight promise in `libs/shared-auth-members/src/auth.ts` (`let refreshPromise`) and a helper `refreshTokensMembers` so concurrent calls to `getTokensMembers` reuse a single `POST /refresh` invocation and avoid multiple refresh rotations. 
- Restored GCRA-based per-IP rate limiting in `apps/backend/src/routes/auth_v2.rs` by importing `axum_gcra` and attaching a `RateLimitLayer<RealIp>` to the `OpenApiRouter`, with quotas applied for `POST /login`, `POST /activate`, `POST /password/reset`, and `POST /password/reset/confirm`.
- Minor imports and formatting changes to support the new rate limit layer (added `Method`, `RateLimitLayer`, `Quota`, `RealIp`, and `Duration`).

### Testing

- Ran `npx nx lint shared-auth-members` and it completed successfully. 
- Ran `cd apps/backend && cargo check` and it completed successfully (compile warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34d736e5ac832192314568cca5db43)