### PR TITLE
fix: プレビュー環境のAPI/Authエンドポイントをv3/v2へ更新

### DIFF
--- a/apps/admin/.env.preview
+++ b/apps/admin/.env.preview
@@ -1,3 +1,3 @@
-API_URL=https://api-preview.koudaisai.jp/api/v2
-AUTH_URL=https://api-preview.koudaisai.jp/auth/v1
+API_URL=https://api-preview.koudaisai.jp/api/v3
+AUTH_URL=https://api-preview.koudaisai.jp/auth/v2
 PLANS_INFO_API_URL=https://api-preview.koudaisai.jp/api/plans_info

--- a/apps/portal/.env.preview
+++ b/apps/portal/.env.preview
@@ -1,3 +1,3 @@
-API_URL=https://portal-preview.koudaisai.jp/api/v2
-AUTH_URL=https://portal-preview.koudaisai.jp/auth/v1
+API_URL=https://api-preview.koudaisai.jp/api/v3
+AUTH_URL=https://api-preview.koudaisai.jp/auth/v2
 PLANS_INFO_API_URL=https://portal-preview.koudaisai.jp/api/plans_info


### PR DESCRIPTION
## 概要

プレビュー環境（admin / portal）の `.env.preview` が旧バージョンのエンドポイントを指していたため、アカウント有効化が失敗していた問題を修正します。

## 問題

フロントエンドは認証を `/auth/v2`（Cookie回転）、リソースを `/api/v3` へ移行済みですが、`.env.preview` の `AUTH_URL` / `API_URL` が旧エンドポイント（`/auth/v1` / `/api/v2`）を指したままでした。

このため、アカウント有効化フローで `POST /auth/v1/activate` が**ルーティングレベルで404**となり、フロント側の `switch (response.status)` で 404 → 「指定されたmアドレスが見つかりません」というメッセージが表示されていました（実際には存在しないルートへのリクエストが原因で、mアドレスの有無とは無関係）。

## 変更内容

- `apps/admin/.env.preview`: `AUTH_URL` を `/auth/v2`、`API_URL` を `/api/v3` へ更新
- `apps/portal/.env.preview`: 同上（あわせてホストを `api-preview.koudaisai.jp` に統一）

🤖 Generated with [Claude Code](https://claude.com/claude-code)