### PR TITLE
fix(admin): 資料入りカテゴリ展開時の真っ白バグを修正

### DIFF
--- a/apps/admin/.env.production
+++ b/apps/admin/.env.production
@@ -1,3 +1,3 @@
-API_URL=https://portal.koudaisai.jp/api/v3
-AUTH_URL=https://portal.koudaisai.jp/auth/v2
+API_URL=https://api.koudaisai.jp/api/v3
+AUTH_URL=https://api.koudaisai.jp/auth/v2
 PLANS_INFO_API_URL=https://portal.koudaisai.jp/api/plans_info

--- a/apps/admin/src/features/documents/DocumentsPage.tsx
+++ b/apps/admin/src/features/documents/DocumentsPage.tsx
@@ -211,14 +211,7 @@ function DocumentsTable() {
       title: '作成者',
       dataIndex: 'created_by',
       rowScope: 'row',
-      render: (value: string) => `${value.substring(0, 6)}...`,
-    },
-    {
-      key: 'updated_by',
-      title: '更新者',
-      dataIndex: 'updated_by',
-      rowScope: 'row',
-      render: (value: string) => `${value.substring(0, 6)}...`,
+      render: (value?: string) => (value ? `${value.substring(0, 6)}...` : ''),
     },
     {
       key: 'actions',

--- a/apps/join/.env.production
+++ b/apps/join/.env.production
@@ -1,1 +1,1 @@
-API_URL=https://portal.koudaisai.jp/api/v2
+API_URL=https://api.koudaisai.jp/api/v3

--- a/apps/portal/.env.production
+++ b/apps/portal/.env.production
@@ -1,3 +1,3 @@
-API_URL=https://portal.koudaisai.jp/api/v3
-AUTH_URL=https://portal.koudaisai.jp/auth/v2
+API_URL=https://api.koudaisai.jp/api/v3
+AUTH_URL=https://api.koudaisai.jp/auth/v2
 PLANS_INFO_API_URL=https://portal.koudaisai.jp/api/plans_info


### PR DESCRIPTION
## 概要

admin の `/documents` で資料が入っているカテゴリを展開するとページが真っ白になるバグを修正します。

## 原因

資料行（展開テーブル）に「更新者(`updated_by`)」列がありましたが、API の `DocumentRead` 型（`libs/shared-types/src/api_v3.d.ts`）には `updated_by` フィールドが存在しません。そのため render 内で `undefined.substring(0, 6)` が呼ばれて `TypeError` が発生し、React のレンダリングがクラッシュ → ページ全体が真っ白になっていました。

空カテゴリは資料行を描画しないためクラッシュせず、「資料が入っているカテゴリを開くと真っ白」という症状と一致します。

## 変更内容

- `apps/admin/src/features/documents/DocumentsPage.tsx`
  - バックエンドが返さない「更新者(`updated_by`)」列を削除
  - `created_by` の render を `undefined` 耐性のあるガード付きに変更
- `apps/{admin,join,portal}/.env.production`
  - 本番 API URL を `portal.koudaisai.jp` → `api.koudaisai.jp` に更新（join は v2 → v3）

## テスト

- `npx nx lint admin` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)