### PR TITLE
fix(docs): set SQLX_OFFLINE in api build.sh so CI doesn't hit a live DB

### DIFF
--- a/docs/api/build.sh
+++ b/docs/api/build.sh
@@ -4,6 +4,13 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+# sqlx の query! マクロをオフライン(コミット済み .sqlx キャッシュ)で検査させる。
+# apps/backend/.cargo/config.toml にも同設定があるが、cargo の config 探索は
+# manifest ではなくカレントディレクトリ起点なので、ここ(docs/api)から
+# --manifest-path で起動すると読まれない。CI(クリーンビルド)で live DB へ
+# 接続しようとして失敗するため、明示的に設定する。
+export SQLX_OFFLINE=true
+
 BACKEND=../../apps/backend/Cargo.toml
 cargo run --quiet --manifest-path "$BACKEND" -- --dump-openapi=api_v3 > api_v3/openapi.json
 cargo run --quiet --manifest-path "$BACKEND" -- --dump-openapi=auth_v2 > auth_v2/openapi.json


### PR DESCRIPTION
## 概要

`docs/api/build.sh` が CI で失敗する問題を修正します。

## 原因

`apps/backend/.cargo/config.toml` に `SQLX_OFFLINE = "true"` が設定されており、これが効けば sqlx の `query!` マクロはコミット済み `.sqlx/` キャッシュでオフライン検査できます。

しかし **cargo の config 探索はカレントディレクトリ起点で上方向に遡る** 仕様で、`--manifest-path` の場所は参照されません。`build.sh` は `docs/api` に `cd` してから `--manifest-path ../../apps/backend/Cargo.toml` で起動するため、`docs/api` → `docs` → ルート… と探索され、`apps/backend/.cargo/config.toml` に**到達しません**。

結果 `SQLX_OFFLINE` が未設定のまま、CI のクリーンビルドで sqlx の `query!` マクロが live DB へ接続を試みて失敗します。ローカルでは `target/` のキャッシュやローカル DB のおかげで顕在化していませんでした。

## 修正

`build.sh` 冒頭で `export SQLX_OFFLINE=true` を明示し、CWD 依存をなくします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)