### PR TITLE
fix(docs): set SQLX_OFFLINE in update_clients.sh so CI doesn't hit a live DB

### DIFF
--- a/docs/api/update_clients.sh
+++ b/docs/api/update_clients.sh
@@ -5,6 +5,13 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+# sqlx の query! マクロをオフライン(コミット済み .sqlx キャッシュ)で検査させる。
+# apps/backend/.cargo/config.toml にも同設定があるが、cargo の config 探索は
+# manifest ではなくカレントディレクトリ起点なので、ここ(docs/api)から
+# --manifest-path で起動すると読まれない。CI(クリーンビルド)で live DB へ
+# 接続しようとして失敗するため、明示的に設定する。
+export SQLX_OFFLINE=true
+
 BACKEND=../../apps/backend/Cargo.toml
 cargo run --quiet --manifest-path "$BACKEND" -- --dump-openapi=api_v3 > api_v3/openapi.json
 cargo run --quiet --manifest-path "$BACKEND" -- --dump-openapi=auth_v2 > auth_v2/openapi.json


### PR DESCRIPTION
## 概要

`docs-api:update-clients` の CI が `error returned from database: (code: 1) no such table: approval_requests` 等で失敗していたのを修正します。

## 原因

`docs/api/update_clients.sh` は `docs/api/` をカレントディレクトリにして `cargo run --manifest-path ../../apps/backend/Cargo.toml` を実行しています。cargo の config 探索は manifest ではなく**カレントディレクトリ起点**のため、`apps/backend/.cargo/config.toml`（`SQLX_OFFLINE = "true"`）が読まれません。結果、sqlx の `query!` マクロがコンパイル時に live DB へ接続しようとし、CI のクリーン環境で失敗していました。

これは以前 `build.sh` で修正された（`58a1363`）のと同一のバグで、`update_clients.sh` に適用漏れがありました。

## 修正

`build.sh` と同じく `export SQLX_OFFLINE=true` を明示的に追加。`docs/api` から手元で openapi dump が DB なしで成功することを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)