### PR TITLE
feat(config): activation tokenのデフォルトttlを六ヶ月に変更

### DIFF
--- a/apps/backend/src/config.rs
+++ b/apps/backend/src/config.rs
@@ -168,7 +168,7 @@ impl Default for AuthV3 {
             session_absolute_ttl_secs: 60 * 60 * 24 * 183, // ~6 か月
             session_idle_ttl_secs: 60 * 60 * 24 * 183,
             max_sessions_per_user: 10,
-            activation_token_ttl_secs: 60 * 60 * 48,
+            activation_token_ttl_secs: 60 * 60 * 24 * 183, // 6 か月
             reset_token_ttl_secs: 60 * 30,
             refresh_cookie_name: "__Host-refresh_token".to_string(),
             refresh_cookie_secure: true,


### PR DESCRIPTION
## 概要

activation token（参加団体の初回ログイン有効化トークン）のデフォルト TTL を六ヶ月に変更します。

## 変更点

- `apps/backend/src/config.rs` で activation token のデフォルト TTL を六ヶ月に設定

## 動機

有効化トークンの有効期限が短く、団体が初回ログインを行う前に失効してしまうケースに対応するため、デフォルト値を延長します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)