### PR TITLE
Introduce ErrorMessage type and return JSON error bodies in API v3

### DIFF
--- a/apps/backend/src/routes/api_v3.rs
+++ b/apps/backend/src/routes/api_v3.rs
@@ -24,6 +24,43 @@ const UTIL_TAG: &str = "util";
 /// (`ActorContext` 抽出子が `FromRequestParts<AuthV2State>` のため)。
 pub(crate) type V3State = crate::routes::auth_v2::AuthV2State;
 
+#[derive(serde::Serialize, utoipa::ToSchema)]
+pub(super) struct ErrorMessage {
+    message: String,
+}
+
+impl ErrorMessage {
+    pub(super) fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    pub(super) fn bad_request() -> Self {
+        Self::new("Invalid input")
+    }
+
+    pub(super) fn forbidden() -> Self {
+        Self::new("Forbidden")
+    }
+
+    pub(super) fn not_found() -> Self {
+        Self::new("Not found")
+    }
+
+    pub(super) fn unprocessable_entity() -> Self {
+        Self::new("Invalid input")
+    }
+
+    pub(super) fn conflict() -> Self {
+        Self::new("Conflict")
+    }
+
+    pub(super) fn internal_server_error() -> Self {
+        Self::new("Internal server error")
+    }
+}
+
 /// レスポンス DTO のスキーマ登録用ベースドキュメント。
 /// `#[http_response]` マクロは `$ref` を吐くが components へスキーマを登録しないため、
 /// レスポンス系 DTO をここで明示的に列挙して OpenApi の components に載せる
@@ -32,6 +69,7 @@ pub(crate) type V3State = crate::routes::auth_v2::AuthV2State;
 #[openapi(components(schemas(
     groups::GroupRead,
     groups::MemberRead,
+    ErrorMessage,
     users::UserRead,
     users::UserCreated,
     users::MAddressUpdated,

--- a/apps/backend/src/routes/api_v3/approval_requests/handlers.rs
+++ b/apps/backend/src/routes/api_v3/approval_requests/handlers.rs
@@ -1,3 +1,4 @@
+use super::super::ErrorMessage;
 use super::super::V3State;
 use super::dto::{ApprovalActionBody, ApprovalRequestCreate, ApprovalRequestRead};
 use crate::application::error::{ApplicationOperationError, DeleteError, UpdateError};
@@ -28,9 +29,9 @@ pub enum GetApprovalRequestsResponse {
     #[response(status = OK)]
     Ok(Vec<ApprovalRequestRead>),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -56,12 +57,16 @@ pub async fn get_approval_requests(
             .get_by_group_members(&actor, uid)
             .await
     } else {
-        return GetApprovalRequestsResponse::Forbidden;
+        return GetApprovalRequestsResponse::Forbidden(ErrorMessage::forbidden());
     };
     match result {
         Ok(v) => GetApprovalRequestsResponse::Ok(v.iter().map(ApprovalRequestRead::from).collect()),
-        Err(ApplicationOperationError::Unauthorized) => GetApprovalRequestsResponse::Forbidden,
-        Err(_) => GetApprovalRequestsResponse::InternalServerError,
+        Err(ApplicationOperationError::Unauthorized) => {
+            GetApprovalRequestsResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(_) => {
+            GetApprovalRequestsResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }
 
@@ -70,11 +75,11 @@ pub enum PostApprovalRequestResponse {
     #[response(status = CREATED)]
     Created(ApprovalRequestRead),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = UNPROCESSABLE_ENTITY, description = "Invalid approval request")]
-    UnprocessableEntity,
+    UnprocessableEntity(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -99,13 +104,19 @@ pub async fn post_approval_request(
     {
         Ok(id) => match st.app.approval_request().get_by_id(&actor, id).await {
             Ok(Some(ar)) => PostApprovalRequestResponse::Created(ApprovalRequestRead::from(&ar)),
-            _ => PostApprovalRequestResponse::InternalServerError,
+            _ => PostApprovalRequestResponse::InternalServerError(
+                ErrorMessage::internal_server_error(),
+            ),
         },
-        Err(ApplicationOperationError::Unauthorized) => PostApprovalRequestResponse::Forbidden,
-        Err(ApplicationOperationError::InvalidInput(_)) => {
-            PostApprovalRequestResponse::UnprocessableEntity
+        Err(ApplicationOperationError::Unauthorized) => {
+            PostApprovalRequestResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(_) => PostApprovalRequestResponse::InternalServerError,
+        Err(ApplicationOperationError::InvalidInput(_)) => {
+            PostApprovalRequestResponse::UnprocessableEntity(ErrorMessage::unprocessable_entity())
+        }
+        Err(_) => {
+            PostApprovalRequestResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }
 
@@ -114,11 +125,11 @@ pub enum GetApprovalRequestResponse {
     #[response(status = OK, description = "Approval request found")]
     Ok(ApprovalRequestRead),
     #[response(status = NOT_FOUND, description = "Approval request not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -141,9 +152,13 @@ pub async fn get_approval_request(
         .await
     {
         Ok(Some(ar)) => GetApprovalRequestResponse::Ok(ApprovalRequestRead::from(&ar)),
-        Ok(None) => GetApprovalRequestResponse::NotFound,
-        Err(ApplicationOperationError::Unauthorized) => GetApprovalRequestResponse::Forbidden,
-        Err(_) => GetApprovalRequestResponse::InternalServerError,
+        Ok(None) => GetApprovalRequestResponse::NotFound(ErrorMessage::not_found()),
+        Err(ApplicationOperationError::Unauthorized) => {
+            GetApprovalRequestResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(_) => {
+            GetApprovalRequestResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }
 
@@ -152,13 +167,13 @@ pub enum ApproveApprovalRequestResponse {
     #[response(status = OK, description = "Approval request approved")]
     Ok(ApprovalRequestRead),
     #[response(status = NOT_FOUND, description = "Approval request not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = CONFLICT, description = "Approval request is not pending")]
-    Conflict,
+    Conflict(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -183,12 +198,18 @@ pub async fn approve_approval_request(
         .await
     {
         Ok(ar) => ApproveApprovalRequestResponse::Ok(ApprovalRequestRead::from(&ar)),
-        Err(ApplicationOperationError::Unauthorized) => ApproveApprovalRequestResponse::Forbidden,
-        Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
-            ApproveApprovalRequestResponse::NotFound
+        Err(ApplicationOperationError::Unauthorized) => {
+            ApproveApprovalRequestResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(ApplicationOperationError::InvalidInput(_)) => ApproveApprovalRequestResponse::Conflict,
-        Err(_) => ApproveApprovalRequestResponse::InternalServerError,
+        Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
+            ApproveApprovalRequestResponse::NotFound(ErrorMessage::not_found())
+        }
+        Err(ApplicationOperationError::InvalidInput(_)) => {
+            ApproveApprovalRequestResponse::Conflict(ErrorMessage::conflict())
+        }
+        Err(_) => ApproveApprovalRequestResponse::InternalServerError(
+            ErrorMessage::internal_server_error(),
+        ),
     }
 }
 
@@ -197,13 +218,13 @@ pub enum RejectApprovalRequestResponse {
     #[response(status = OK, description = "Approval request rejected")]
     Ok(ApprovalRequestRead),
     #[response(status = NOT_FOUND, description = "Approval request not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = CONFLICT, description = "Approval request is not pending")]
-    Conflict,
+    Conflict(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -228,12 +249,18 @@ pub async fn reject_approval_request(
         .await
     {
         Ok(ar) => RejectApprovalRequestResponse::Ok(ApprovalRequestRead::from(&ar)),
-        Err(ApplicationOperationError::Unauthorized) => RejectApprovalRequestResponse::Forbidden,
-        Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
-            RejectApprovalRequestResponse::NotFound
+        Err(ApplicationOperationError::Unauthorized) => {
+            RejectApprovalRequestResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(ApplicationOperationError::InvalidInput(_)) => RejectApprovalRequestResponse::Conflict,
-        Err(_) => RejectApprovalRequestResponse::InternalServerError,
+        Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
+            RejectApprovalRequestResponse::NotFound(ErrorMessage::not_found())
+        }
+        Err(ApplicationOperationError::InvalidInput(_)) => {
+            RejectApprovalRequestResponse::Conflict(ErrorMessage::conflict())
+        }
+        Err(_) => {
+            RejectApprovalRequestResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }
 
@@ -242,13 +269,13 @@ pub enum CloseApprovalRequestResponse {
     #[response(status = OK, description = "Approval request closed")]
     Ok(ApprovalRequestRead),
     #[response(status = NOT_FOUND, description = "Approval request not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = CONFLICT, description = "Approval request is not pending")]
-    Conflict,
+    Conflict(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -268,15 +295,23 @@ pub async fn close_approval_request(
     match st.app.approval_request().close(&actor, id).await {
         Ok(()) => match st.app.approval_request().get_by_id(&actor, id).await {
             Ok(Some(ar)) => CloseApprovalRequestResponse::Ok(ApprovalRequestRead::from(&ar)),
-            Ok(None) => CloseApprovalRequestResponse::NotFound,
-            _ => CloseApprovalRequestResponse::InternalServerError,
+            Ok(None) => CloseApprovalRequestResponse::NotFound(ErrorMessage::not_found()),
+            _ => CloseApprovalRequestResponse::InternalServerError(
+                ErrorMessage::internal_server_error(),
+            ),
         },
-        Err(ApplicationOperationError::Unauthorized) => CloseApprovalRequestResponse::Forbidden,
-        Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
-            CloseApprovalRequestResponse::NotFound
+        Err(ApplicationOperationError::Unauthorized) => {
+            CloseApprovalRequestResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(ApplicationOperationError::InvalidInput(_)) => CloseApprovalRequestResponse::Conflict,
-        Err(_) => CloseApprovalRequestResponse::InternalServerError,
+        Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
+            CloseApprovalRequestResponse::NotFound(ErrorMessage::not_found())
+        }
+        Err(ApplicationOperationError::InvalidInput(_)) => {
+            CloseApprovalRequestResponse::Conflict(ErrorMessage::conflict())
+        }
+        Err(_) => {
+            CloseApprovalRequestResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }
 
@@ -285,11 +320,11 @@ pub enum DeleteApprovalRequestResponse {
     #[response(status = NO_CONTENT, description = "Approval request deleted")]
     NoContent,
     #[response(status = NOT_FOUND, description = "Approval request not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -312,10 +347,14 @@ pub async fn delete_approval_request(
         .await
     {
         Ok(()) => DeleteApprovalRequestResponse::NoContent,
-        Err(ApplicationOperationError::Unauthorized) => DeleteApprovalRequestResponse::Forbidden,
-        Err(ApplicationOperationError::OperationFailed(DeleteError::NotFound)) => {
-            DeleteApprovalRequestResponse::NotFound
+        Err(ApplicationOperationError::Unauthorized) => {
+            DeleteApprovalRequestResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(_) => DeleteApprovalRequestResponse::InternalServerError,
+        Err(ApplicationOperationError::OperationFailed(DeleteError::NotFound)) => {
+            DeleteApprovalRequestResponse::NotFound(ErrorMessage::not_found())
+        }
+        Err(_) => {
+            DeleteApprovalRequestResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }

--- a/apps/backend/src/routes/api_v3/document_categories/handlers.rs
+++ b/apps/backend/src/routes/api_v3/document_categories/handlers.rs
@@ -1,3 +1,4 @@
+use super::super::ErrorMessage;
 use super::super::V3State;
 use super::dto::{DocumentCategoryCreate, DocumentCategoryRead, DocumentCategoryUpdate};
 use crate::application::error::{ApplicationOperationError, DeleteError, UpdateError};
@@ -19,9 +20,9 @@ pub enum GetDocumentCategoriesResponse {
     #[response(status = OK)]
     Ok(Vec<DocumentCategoryRead>),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -40,8 +41,12 @@ pub async fn get_document_categories(
             cats.sort_by_key(|c| c.created_at());
             GetDocumentCategoriesResponse::Ok(cats.iter().map(DocumentCategoryRead::from).collect())
         }
-        Err(ApplicationOperationError::Unauthorized) => GetDocumentCategoriesResponse::Forbidden,
-        Err(_) => GetDocumentCategoriesResponse::InternalServerError,
+        Err(ApplicationOperationError::Unauthorized) => {
+            GetDocumentCategoriesResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(_) => {
+            GetDocumentCategoriesResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }
 
@@ -50,11 +55,11 @@ pub enum GetDocumentCategoryResponse {
     #[response(status = OK, description = "Document category found")]
     Ok(DocumentCategoryRead),
     #[response(status = NOT_FOUND, description = "Document category not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -72,9 +77,13 @@ pub async fn get_document_category(
 ) -> GetDocumentCategoryResponse {
     match st.app.document_category().get_by_id(&actor, path.id).await {
         Ok(Some(cat)) => GetDocumentCategoryResponse::Ok(DocumentCategoryRead::from(&cat)),
-        Ok(None) => GetDocumentCategoryResponse::NotFound,
-        Err(ApplicationOperationError::Unauthorized) => GetDocumentCategoryResponse::Forbidden,
-        Err(_) => GetDocumentCategoryResponse::InternalServerError,
+        Ok(None) => GetDocumentCategoryResponse::NotFound(ErrorMessage::not_found()),
+        Err(ApplicationOperationError::Unauthorized) => {
+            GetDocumentCategoryResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(_) => {
+            GetDocumentCategoryResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }
 
@@ -83,11 +92,11 @@ pub enum PostDocumentCategoryResponse {
     #[response(status = CREATED)]
     Created(DocumentCategoryRead),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = UNPROCESSABLE_ENTITY, description = "Invalid document category")]
-    UnprocessableEntity,
+    UnprocessableEntity(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -110,11 +119,15 @@ pub async fn post_document_category(
         .await
     {
         Ok(cat) => PostDocumentCategoryResponse::Created(DocumentCategoryRead::from(&cat)),
-        Err(ApplicationOperationError::Unauthorized) => PostDocumentCategoryResponse::Forbidden,
-        Err(ApplicationOperationError::InvalidInput(_)) => {
-            PostDocumentCategoryResponse::UnprocessableEntity
+        Err(ApplicationOperationError::Unauthorized) => {
+            PostDocumentCategoryResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(_) => PostDocumentCategoryResponse::InternalServerError,
+        Err(ApplicationOperationError::InvalidInput(_)) => {
+            PostDocumentCategoryResponse::UnprocessableEntity(ErrorMessage::unprocessable_entity())
+        }
+        Err(_) => {
+            PostDocumentCategoryResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }
 
@@ -123,13 +136,13 @@ pub enum PatchDocumentCategoryResponse {
     #[response(status = OK, description = "Document category updated")]
     Ok(DocumentCategoryRead),
     #[response(status = NOT_FOUND, description = "Document category not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = UNPROCESSABLE_ENTITY, description = "Invalid document category")]
-    UnprocessableEntity,
+    UnprocessableEntity(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -155,17 +168,23 @@ pub async fn patch_document_category(
     {
         Ok(()) => match st.app.document_category().get_by_id(&actor, path.id).await {
             Ok(Some(cat)) => PatchDocumentCategoryResponse::Ok(DocumentCategoryRead::from(&cat)),
-            Ok(None) => PatchDocumentCategoryResponse::NotFound,
-            _ => PatchDocumentCategoryResponse::InternalServerError,
+            Ok(None) => PatchDocumentCategoryResponse::NotFound(ErrorMessage::not_found()),
+            _ => PatchDocumentCategoryResponse::InternalServerError(
+                ErrorMessage::internal_server_error(),
+            ),
         },
-        Err(ApplicationOperationError::Unauthorized) => PatchDocumentCategoryResponse::Forbidden,
+        Err(ApplicationOperationError::Unauthorized) => {
+            PatchDocumentCategoryResponse::Forbidden(ErrorMessage::forbidden())
+        }
         Err(ApplicationOperationError::InvalidInput(_)) => {
-            PatchDocumentCategoryResponse::UnprocessableEntity
+            PatchDocumentCategoryResponse::UnprocessableEntity(ErrorMessage::unprocessable_entity())
         }
         Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
-            PatchDocumentCategoryResponse::NotFound
+            PatchDocumentCategoryResponse::NotFound(ErrorMessage::not_found())
         }
-        Err(_) => PatchDocumentCategoryResponse::InternalServerError,
+        Err(_) => {
+            PatchDocumentCategoryResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }
 
@@ -174,11 +193,11 @@ pub enum DeleteDocumentCategoryResponse {
     #[response(status = NO_CONTENT, description = "Document category deleted")]
     NoContent,
     #[response(status = NOT_FOUND, description = "Document category not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -201,10 +220,14 @@ pub async fn delete_document_category(
         .await
     {
         Ok(()) => DeleteDocumentCategoryResponse::NoContent,
-        Err(ApplicationOperationError::Unauthorized) => DeleteDocumentCategoryResponse::Forbidden,
-        Err(ApplicationOperationError::OperationFailed(DeleteError::NotFound)) => {
-            DeleteDocumentCategoryResponse::NotFound
+        Err(ApplicationOperationError::Unauthorized) => {
+            DeleteDocumentCategoryResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(_) => DeleteDocumentCategoryResponse::InternalServerError,
+        Err(ApplicationOperationError::OperationFailed(DeleteError::NotFound)) => {
+            DeleteDocumentCategoryResponse::NotFound(ErrorMessage::not_found())
+        }
+        Err(_) => DeleteDocumentCategoryResponse::InternalServerError(
+            ErrorMessage::internal_server_error(),
+        ),
     }
 }

--- a/apps/backend/src/routes/api_v3/documents/handlers.rs
+++ b/apps/backend/src/routes/api_v3/documents/handlers.rs
@@ -1,3 +1,4 @@
+use super::super::ErrorMessage;
 use super::super::V3State;
 use super::super::document_categories::DocumentCategoryRead;
 use super::dto::{DocumentCreate, DocumentRead, DocumentUpdate, DocumentsByCategoryEntry};
@@ -27,7 +28,7 @@ pub enum GetDocumentsResponse {
     #[response(status = OK)]
     Ok(Vec<DocumentRead>),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -53,7 +54,7 @@ pub async fn get_documents(
                 .map(DocumentRead::from)
                 .collect(),
         ),
-        Err(_) => GetDocumentsResponse::InternalServerError,
+        Err(_) => GetDocumentsResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -70,7 +71,7 @@ pub enum GetDocumentsByCategoryResponse {
     #[response(status = OK)]
     Ok(Vec<DocumentsByCategoryEntry>),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -87,7 +88,9 @@ pub async fn get_documents_by_category(
     Query(query): Query<DocumentsByCategoryQuery>,
 ) -> GetDocumentsByCategoryResponse {
     let Ok(by_category) = st.app.document().get_by_category(&actor).await else {
-        return GetDocumentsByCategoryResponse::InternalServerError;
+        return GetDocumentsByCategoryResponse::InternalServerError(
+            ErrorMessage::internal_server_error(),
+        );
     };
 
     // カテゴリのメタ情報。閲覧権限が無い(非管理者)場合は空とし、id のみでグルーピングする。
@@ -155,11 +158,11 @@ pub enum PostDocumentResponse {
     #[response(status = CREATED)]
     Created(DocumentRead),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = UNPROCESSABLE_ENTITY, description = "Invalid document")]
-    UnprocessableEntity,
+    UnprocessableEntity(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -188,11 +191,13 @@ pub async fn post_document(
         .await
     {
         Ok(doc) => PostDocumentResponse::Created(DocumentRead::from(&doc)),
-        Err(ApplicationOperationError::Unauthorized) => PostDocumentResponse::Forbidden,
-        Err(ApplicationOperationError::InvalidInput(_)) => {
-            PostDocumentResponse::UnprocessableEntity
+        Err(ApplicationOperationError::Unauthorized) => {
+            PostDocumentResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(_) => PostDocumentResponse::InternalServerError,
+        Err(ApplicationOperationError::InvalidInput(_)) => {
+            PostDocumentResponse::UnprocessableEntity(ErrorMessage::unprocessable_entity())
+        }
+        Err(_) => PostDocumentResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -201,9 +206,9 @@ pub enum GetDocumentResponse {
     #[response(status = OK, description = "Document found")]
     Ok(DocumentRead),
     #[response(status = NOT_FOUND, description = "Document not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -221,8 +226,8 @@ pub async fn get_document(
 ) -> GetDocumentResponse {
     match st.app.document().get_by_id(&actor, path.id).await {
         Ok(Some(doc)) => GetDocumentResponse::Ok(DocumentRead::from(&doc)),
-        Ok(None) => GetDocumentResponse::NotFound,
-        Err(_) => GetDocumentResponse::InternalServerError,
+        Ok(None) => GetDocumentResponse::NotFound(ErrorMessage::not_found()),
+        Err(_) => GetDocumentResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -231,13 +236,13 @@ pub enum PatchDocumentResponse {
     #[response(status = OK, description = "Document updated")]
     Ok(DocumentRead),
     #[response(status = NOT_FOUND, description = "Document not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = UNPROCESSABLE_ENTITY, description = "Invalid document")]
-    UnprocessableEntity,
+    UnprocessableEntity(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -270,17 +275,21 @@ pub async fn patch_document(
     {
         Ok(()) => match st.app.document().get_by_id(&actor, path.id).await {
             Ok(Some(doc)) => PatchDocumentResponse::Ok(DocumentRead::from(&doc)),
-            Ok(None) => PatchDocumentResponse::NotFound,
-            Err(_) => PatchDocumentResponse::InternalServerError,
+            Ok(None) => PatchDocumentResponse::NotFound(ErrorMessage::not_found()),
+            Err(_) => {
+                PatchDocumentResponse::InternalServerError(ErrorMessage::internal_server_error())
+            }
         },
-        Err(ApplicationOperationError::Unauthorized) => PatchDocumentResponse::Forbidden,
+        Err(ApplicationOperationError::Unauthorized) => {
+            PatchDocumentResponse::Forbidden(ErrorMessage::forbidden())
+        }
         Err(ApplicationOperationError::InvalidInput(_)) => {
-            PatchDocumentResponse::UnprocessableEntity
+            PatchDocumentResponse::UnprocessableEntity(ErrorMessage::unprocessable_entity())
         }
         Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
-            PatchDocumentResponse::NotFound
+            PatchDocumentResponse::NotFound(ErrorMessage::not_found())
         }
-        Err(_) => PatchDocumentResponse::InternalServerError,
+        Err(_) => PatchDocumentResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -289,11 +298,11 @@ pub enum DeleteDocumentResponse {
     #[response(status = NO_CONTENT, description = "Document deleted")]
     NoContent,
     #[response(status = NOT_FOUND, description = "Document not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -311,10 +320,14 @@ pub async fn delete_document(
 ) -> DeleteDocumentResponse {
     match st.app.document().delete_document(&actor, path.id).await {
         Ok(()) => DeleteDocumentResponse::NoContent,
-        Err(ApplicationOperationError::Unauthorized) => DeleteDocumentResponse::Forbidden,
-        Err(ApplicationOperationError::OperationFailed(DeleteError::NotFound)) => {
-            DeleteDocumentResponse::NotFound
+        Err(ApplicationOperationError::Unauthorized) => {
+            DeleteDocumentResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(_) => DeleteDocumentResponse::InternalServerError,
+        Err(ApplicationOperationError::OperationFailed(DeleteError::NotFound)) => {
+            DeleteDocumentResponse::NotFound(ErrorMessage::not_found())
+        }
+        Err(_) => {
+            DeleteDocumentResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }

--- a/apps/backend/src/routes/api_v3/files/handlers.rs
+++ b/apps/backend/src/routes/api_v3/files/handlers.rs
@@ -1,3 +1,4 @@
+use super::super::ErrorMessage;
 use super::super::V3State;
 use super::dto::{FileDownloadResponse, FileUploadRequest, FileUploadResponse};
 use crate::application::error::ApplicationError;
@@ -15,9 +16,9 @@ pub enum PostFileUploadResponse {
     #[response(status = OK, description = "Returns the presigned upload URL and key")]
     Ok(FileUploadResponse),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -38,8 +39,12 @@ pub async fn post_file_upload(
             presigned_url: ticket.presigned_url,
             key: ticket.key,
         }),
-        Err(ApplicationError::Unauthorized) => PostFileUploadResponse::Forbidden,
-        Err(_) => PostFileUploadResponse::InternalServerError,
+        Err(ApplicationError::Unauthorized) => {
+            PostFileUploadResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(_) => {
+            PostFileUploadResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }
 
@@ -64,8 +69,8 @@ pub struct FileDownloadQuery {
     responses(
         (status = OK, description = "Returns the presigned download URL", body = FileDownloadResponse),
         (status = FOUND, description = "Redirect to the presigned URL (when redirect=true)"),
-        (status = FORBIDDEN, description = "Forbidden"),
-        (status = INTERNAL_SERVER_ERROR, description = "Internal server error"),
+        (status = FORBIDDEN, description = "Forbidden", body = ErrorMessage),
+        (status = INTERNAL_SERVER_ERROR, description = "Internal server error", body = ErrorMessage),
     ),
     tag = super::super::FILES_TAG
 )]
@@ -84,7 +89,11 @@ pub async fn get_file_download(
             if query.redirect {
                 match HeaderValue::from_str(&url) {
                     Ok(loc) => (StatusCode::FOUND, [(header::LOCATION, loc)]).into_response(),
-                    Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+                    Err(_) => (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorMessage::internal_server_error()),
+                    )
+                        .into_response(),
                 }
             } else {
                 (
@@ -94,7 +103,13 @@ pub async fn get_file_download(
                     .into_response()
             }
         }
-        Err(ApplicationError::Unauthorized) => StatusCode::FORBIDDEN.into_response(),
-        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        Err(ApplicationError::Unauthorized) => {
+            (StatusCode::FORBIDDEN, Json(ErrorMessage::forbidden())).into_response()
+        }
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorMessage::internal_server_error()),
+        )
+            .into_response(),
     }
 }

--- a/apps/backend/src/routes/api_v3/forms/handlers.rs
+++ b/apps/backend/src/routes/api_v3/forms/handlers.rs
@@ -1,3 +1,4 @@
+use super::super::ErrorMessage;
 use super::super::V3State;
 use super::dto::{FormCreate, FormRead, FormUpdate};
 use crate::application::error::{ApplicationOperationError, DeleteError, UpdateError};
@@ -21,7 +22,7 @@ pub enum GetFormsResponse {
     #[response(status = OK)]
     Ok(Vec<FormRead>),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -34,7 +35,7 @@ pub enum GetFormsResponse {
 pub async fn get_forms(State(st): State<V3State>, actor: ActorContext) -> GetFormsResponse {
     match st.app.form().get_all(&actor).await {
         Ok(forms) => GetFormsResponse::Ok(forms.iter().map(FormRead::from).collect()),
-        Err(_) => GetFormsResponse::InternalServerError,
+        Err(_) => GetFormsResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -43,11 +44,11 @@ pub enum PostFormResponse {
     #[response(status = CREATED)]
     Created(FormRead),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = UNPROCESSABLE_ENTITY, description = "Invalid form")]
-    UnprocessableEntity,
+    UnprocessableEntity(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -79,11 +80,15 @@ pub async fn post_form(
     {
         Ok(form_id) => match st.app.form().get_by_id(&actor, form_id).await {
             Ok(Some(f)) => PostFormResponse::Created(FormRead::from(&f)),
-            _ => PostFormResponse::InternalServerError,
+            _ => PostFormResponse::InternalServerError(ErrorMessage::internal_server_error()),
         },
-        Err(ApplicationOperationError::Unauthorized) => PostFormResponse::Forbidden,
-        Err(ApplicationOperationError::InvalidInput(_)) => PostFormResponse::UnprocessableEntity,
-        Err(_) => PostFormResponse::InternalServerError,
+        Err(ApplicationOperationError::Unauthorized) => {
+            PostFormResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(ApplicationOperationError::InvalidInput(_)) => {
+            PostFormResponse::UnprocessableEntity(ErrorMessage::unprocessable_entity())
+        }
+        Err(_) => PostFormResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -92,9 +97,9 @@ pub enum GetFormResponse {
     #[response(status = OK, description = "Form found")]
     Ok(FormRead),
     #[response(status = NOT_FOUND, description = "Form not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -112,8 +117,8 @@ pub async fn get_form(
 ) -> GetFormResponse {
     match st.app.form().get_by_id(&actor, FormId::new(path.id)).await {
         Ok(Some(f)) => GetFormResponse::Ok(FormRead::from(&f)),
-        Ok(None) => GetFormResponse::NotFound,
-        Err(_) => GetFormResponse::InternalServerError,
+        Ok(None) => GetFormResponse::NotFound(ErrorMessage::not_found()),
+        Err(_) => GetFormResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -122,13 +127,13 @@ pub enum PatchFormResponse {
     #[response(status = OK, description = "Form updated")]
     Ok(FormRead),
     #[response(status = NOT_FOUND, description = "Form not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = UNPROCESSABLE_ENTITY, description = "Invalid form")]
-    UnprocessableEntity,
+    UnprocessableEntity(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -163,14 +168,18 @@ pub async fn patch_form(
     {
         Ok(()) => match st.app.form().get_by_id(&actor, form_id).await {
             Ok(Some(f)) => PatchFormResponse::Ok(FormRead::from(&f)),
-            _ => PatchFormResponse::InternalServerError,
+            _ => PatchFormResponse::InternalServerError(ErrorMessage::internal_server_error()),
         },
-        Err(ApplicationOperationError::Unauthorized) => PatchFormResponse::Forbidden,
-        Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
-            PatchFormResponse::NotFound
+        Err(ApplicationOperationError::Unauthorized) => {
+            PatchFormResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(ApplicationOperationError::InvalidInput(_)) => PatchFormResponse::UnprocessableEntity,
-        Err(_) => PatchFormResponse::InternalServerError,
+        Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
+            PatchFormResponse::NotFound(ErrorMessage::not_found())
+        }
+        Err(ApplicationOperationError::InvalidInput(_)) => {
+            PatchFormResponse::UnprocessableEntity(ErrorMessage::unprocessable_entity())
+        }
+        Err(_) => PatchFormResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -179,11 +188,11 @@ pub enum DeleteFormResponse {
     #[response(status = NO_CONTENT, description = "Form deleted")]
     NoContent,
     #[response(status = NOT_FOUND, description = "Form not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -201,10 +210,12 @@ pub async fn delete_form(
 ) -> DeleteFormResponse {
     match st.app.form().delete(&actor, FormId::new(path.id)).await {
         Ok(()) => DeleteFormResponse::NoContent,
-        Err(ApplicationOperationError::Unauthorized) => DeleteFormResponse::Forbidden,
-        Err(ApplicationOperationError::OperationFailed(DeleteError::NotFound)) => {
-            DeleteFormResponse::NotFound
+        Err(ApplicationOperationError::Unauthorized) => {
+            DeleteFormResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(_) => DeleteFormResponse::InternalServerError,
+        Err(ApplicationOperationError::OperationFailed(DeleteError::NotFound)) => {
+            DeleteFormResponse::NotFound(ErrorMessage::not_found())
+        }
+        Err(_) => DeleteFormResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }

--- a/apps/backend/src/routes/api_v3/groups/handlers.rs
+++ b/apps/backend/src/routes/api_v3/groups/handlers.rs
@@ -1,3 +1,4 @@
+use super::super::ErrorMessage;
 use super::super::V3State;
 use super::dto::{GroupCreate, GroupRead, GroupUpdate, MemberCreate, MemberRead, Role};
 use crate::application::error::{
@@ -21,9 +22,9 @@ pub enum GetGroupsResponse {
     #[response(status = OK)]
     Ok(Vec<GroupRead>),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -36,8 +37,10 @@ pub enum GetGroupsResponse {
 pub async fn get_groups(State(st): State<V3State>, actor: ActorContext) -> GetGroupsResponse {
     match st.app.group().get_all(&actor).await {
         Ok(groups) => GetGroupsResponse::Ok(groups.iter().map(GroupRead::from).collect()),
-        Err(ApplicationOperationError::Unauthorized) => GetGroupsResponse::Forbidden,
-        Err(_) => GetGroupsResponse::InternalServerError,
+        Err(ApplicationOperationError::Unauthorized) => {
+            GetGroupsResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(_) => GetGroupsResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -53,11 +56,11 @@ pub enum PutGroupResponse {
     #[response(status = OK, description = "Group replaced")]
     Ok(GroupRead),
     #[response(status = BAD_REQUEST, description = "Invalid group id or input")]
-    BadRequest,
+    BadRequest(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -76,7 +79,7 @@ pub async fn put_group(
     Json(group): Json<GroupCreate>,
 ) -> PutGroupResponse {
     let Ok(group_id) = GroupId::from_str(&path.id) else {
-        return PutGroupResponse::BadRequest;
+        return PutGroupResponse::BadRequest(ErrorMessage::bad_request());
     };
     let domain_type = (&group.r#type).into();
     let tx = SqliteTransaction::new(st.pool.clone());
@@ -88,7 +91,7 @@ pub async fn put_group(
     {
         Ok(()) => match st.app.group().get_by_id(&actor, group_id).await {
             Ok(Some(g)) => PutGroupResponse::Created(GroupRead::from(&g)),
-            _ => PutGroupResponse::InternalServerError,
+            _ => PutGroupResponse::InternalServerError(ErrorMessage::internal_server_error()),
         },
         // 既存グループ → 名称を置換する(種別は変更不可)。
         Err(ApplicationSequentialOperationError::OperationFailed(InsertError::Conflict)) => {
@@ -99,14 +102,24 @@ pub async fn put_group(
                 .await
             {
                 Ok(g) => PutGroupResponse::Ok(GroupRead::from(&g)),
-                Err(ApplicationOperationError::Unauthorized) => PutGroupResponse::Forbidden,
-                Err(ApplicationOperationError::InvalidInput(_)) => PutGroupResponse::BadRequest,
-                Err(_) => PutGroupResponse::InternalServerError,
+                Err(ApplicationOperationError::Unauthorized) => {
+                    PutGroupResponse::Forbidden(ErrorMessage::forbidden())
+                }
+                Err(ApplicationOperationError::InvalidInput(_)) => {
+                    PutGroupResponse::BadRequest(ErrorMessage::bad_request())
+                }
+                Err(_) => {
+                    PutGroupResponse::InternalServerError(ErrorMessage::internal_server_error())
+                }
             }
         }
-        Err(ApplicationSequentialOperationError::Unauthorized) => PutGroupResponse::Forbidden,
-        Err(ApplicationSequentialOperationError::InvalidInput(_)) => PutGroupResponse::BadRequest,
-        Err(_) => PutGroupResponse::InternalServerError,
+        Err(ApplicationSequentialOperationError::Unauthorized) => {
+            PutGroupResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(ApplicationSequentialOperationError::InvalidInput(_)) => {
+            PutGroupResponse::BadRequest(ErrorMessage::bad_request())
+        }
+        Err(_) => PutGroupResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -115,11 +128,11 @@ pub enum GetGroupResponse {
     #[response(status = OK, description = "Group found")]
     Ok(GroupRead),
     #[response(status = NOT_FOUND, description = "Group not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -131,13 +144,15 @@ pub enum GetGroupResponse {
 )]
 pub async fn get_group_us(State(st): State<V3State>, actor: ActorContext) -> GetGroupResponse {
     let Some(group_id) = actor.primary_group_id() else {
-        return GetGroupResponse::Forbidden;
+        return GetGroupResponse::Forbidden(ErrorMessage::forbidden());
     };
     match st.app.group().get_by_id(&actor, group_id).await {
         Ok(Some(g)) => GetGroupResponse::Ok(GroupRead::from(&g)),
-        Ok(None) => GetGroupResponse::NotFound,
-        Err(ApplicationOperationError::Unauthorized) => GetGroupResponse::Forbidden,
-        Err(_) => GetGroupResponse::InternalServerError,
+        Ok(None) => GetGroupResponse::NotFound(ErrorMessage::not_found()),
+        Err(ApplicationOperationError::Unauthorized) => {
+            GetGroupResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(_) => GetGroupResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -155,13 +170,15 @@ pub async fn get_group(
     Path(path): Path<GroupPath>,
 ) -> GetGroupResponse {
     let Ok(group_id) = GroupId::from_str(&path.id) else {
-        return GetGroupResponse::NotFound;
+        return GetGroupResponse::NotFound(ErrorMessage::not_found());
     };
     match st.app.group().get_by_id(&actor, group_id).await {
         Ok(Some(g)) => GetGroupResponse::Ok(GroupRead::from(&g)),
-        Ok(None) => GetGroupResponse::NotFound,
-        Err(ApplicationOperationError::Unauthorized) => GetGroupResponse::Forbidden,
-        Err(_) => GetGroupResponse::InternalServerError,
+        Ok(None) => GetGroupResponse::NotFound(ErrorMessage::not_found()),
+        Err(ApplicationOperationError::Unauthorized) => {
+            GetGroupResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(_) => GetGroupResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -170,13 +187,13 @@ pub enum PatchGroupResponse {
     #[response(status = OK, description = "Group updated")]
     Ok(GroupRead),
     #[response(status = BAD_REQUEST, description = "Invalid input")]
-    BadRequest,
+    BadRequest(ErrorMessage),
     #[response(status = NOT_FOUND, description = "Group not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -195,25 +212,33 @@ pub async fn patch_group(
     Json(group): Json<GroupUpdate>,
 ) -> PatchGroupResponse {
     let Ok(group_id) = GroupId::from_str(&path.id) else {
-        return PatchGroupResponse::NotFound;
+        return PatchGroupResponse::NotFound(ErrorMessage::not_found());
     };
     // name の指定が無ければ現状を取得して返す(no-op)。
     let Some(name) = group.name else {
         return match st.app.group().get_by_id(&actor, group_id).await {
             Ok(Some(g)) => PatchGroupResponse::Ok(GroupRead::from(&g)),
-            Ok(None) => PatchGroupResponse::NotFound,
-            Err(ApplicationOperationError::Unauthorized) => PatchGroupResponse::Forbidden,
-            Err(_) => PatchGroupResponse::InternalServerError,
+            Ok(None) => PatchGroupResponse::NotFound(ErrorMessage::not_found()),
+            Err(ApplicationOperationError::Unauthorized) => {
+                PatchGroupResponse::Forbidden(ErrorMessage::forbidden())
+            }
+            Err(_) => {
+                PatchGroupResponse::InternalServerError(ErrorMessage::internal_server_error())
+            }
         };
     };
     match st.app.group().rename_group(&actor, group_id, name).await {
         Ok(g) => PatchGroupResponse::Ok(GroupRead::from(&g)),
-        Err(ApplicationOperationError::Unauthorized) => PatchGroupResponse::Forbidden,
-        Err(ApplicationOperationError::InvalidInput(_)) => PatchGroupResponse::BadRequest,
-        Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
-            PatchGroupResponse::NotFound
+        Err(ApplicationOperationError::Unauthorized) => {
+            PatchGroupResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(_) => PatchGroupResponse::InternalServerError,
+        Err(ApplicationOperationError::InvalidInput(_)) => {
+            PatchGroupResponse::BadRequest(ErrorMessage::bad_request())
+        }
+        Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
+            PatchGroupResponse::NotFound(ErrorMessage::not_found())
+        }
+        Err(_) => PatchGroupResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -222,11 +247,11 @@ pub enum DeleteGroupResponse {
     #[response(status = NO_CONTENT, description = "Group deleted")]
     NoContent,
     #[response(status = NOT_FOUND, description = "Group not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -243,15 +268,17 @@ pub async fn delete_group(
     Path(path): Path<GroupPath>,
 ) -> DeleteGroupResponse {
     let Ok(group_id) = GroupId::from_str(&path.id) else {
-        return DeleteGroupResponse::NotFound;
+        return DeleteGroupResponse::NotFound(ErrorMessage::not_found());
     };
     match st.app.group().delete_group(&actor, group_id).await {
         Ok(()) => DeleteGroupResponse::NoContent,
-        Err(ApplicationOperationError::Unauthorized) => DeleteGroupResponse::Forbidden,
-        Err(ApplicationOperationError::OperationFailed(DeleteError::NotFound)) => {
-            DeleteGroupResponse::NotFound
+        Err(ApplicationOperationError::Unauthorized) => {
+            DeleteGroupResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(_) => DeleteGroupResponse::InternalServerError,
+        Err(ApplicationOperationError::OperationFailed(DeleteError::NotFound)) => {
+            DeleteGroupResponse::NotFound(ErrorMessage::not_found())
+        }
+        Err(_) => DeleteGroupResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -266,11 +293,11 @@ pub enum GetMembersResponse {
     #[response(status = OK)]
     Ok(Vec<MemberRead>),
     #[response(status = NOT_FOUND, description = "Group not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -287,13 +314,15 @@ pub async fn get_members(
     Path(path): Path<GroupPath>,
 ) -> GetMembersResponse {
     let Ok(group_id) = GroupId::from_str(&path.id) else {
-        return GetMembersResponse::NotFound;
+        return GetMembersResponse::NotFound(ErrorMessage::not_found());
     };
     match st.app.group().get_members(&actor, group_id).await {
         Ok(Some(members)) => GetMembersResponse::Ok(members.iter().map(MemberRead::from).collect()),
-        Ok(None) => GetMembersResponse::NotFound,
-        Err(ApplicationOperationError::Unauthorized) => GetMembersResponse::Forbidden,
-        Err(_) => GetMembersResponse::InternalServerError,
+        Ok(None) => GetMembersResponse::NotFound(ErrorMessage::not_found()),
+        Err(ApplicationOperationError::Unauthorized) => {
+            GetMembersResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(_) => GetMembersResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -304,13 +333,13 @@ pub enum PutMemberResponse {
     #[response(status = OK, description = "Member replaced")]
     Ok(MemberRead),
     #[response(status = NOT_FOUND, description = "Group not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = UNPROCESSABLE_ENTITY, description = "Invalid for group type")]
-    UnprocessableEntity,
+    UnprocessableEntity(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -329,7 +358,7 @@ pub async fn put_member(
     Json(body): Json<MemberCreate>,
 ) -> PutMemberResponse {
     let Ok(group_id) = GroupId::from_str(&path.id) else {
-        return PutMemberResponse::NotFound;
+        return PutMemberResponse::NotFound(ErrorMessage::not_found());
     };
     let role: DomainRole = (&path.role).into();
     let user_id = UserId::new(body.user_id);
@@ -346,15 +375,19 @@ pub async fn put_member(
             Ok(Some(members)) => match members.iter().find(|m| m.role() == role) {
                 Some(m) if was_replace => PutMemberResponse::Ok(MemberRead::from(m)),
                 Some(m) => PutMemberResponse::Created(MemberRead::from(m)),
-                None => PutMemberResponse::InternalServerError,
+                None => {
+                    PutMemberResponse::InternalServerError(ErrorMessage::internal_server_error())
+                }
             },
-            _ => PutMemberResponse::InternalServerError,
+            _ => PutMemberResponse::InternalServerError(ErrorMessage::internal_server_error()),
         },
-        Err(ApplicationSequentialOperationError::Unauthorized) => PutMemberResponse::Forbidden,
-        Err(ApplicationSequentialOperationError::InvalidInput(_)) => {
-            PutMemberResponse::UnprocessableEntity
+        Err(ApplicationSequentialOperationError::Unauthorized) => {
+            PutMemberResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(_) => PutMemberResponse::InternalServerError,
+        Err(ApplicationSequentialOperationError::InvalidInput(_)) => {
+            PutMemberResponse::UnprocessableEntity(ErrorMessage::unprocessable_entity())
+        }
+        Err(_) => PutMemberResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -363,11 +396,11 @@ pub enum DeleteMemberResponse {
     #[response(status = NO_CONTENT, description = "Member deleted")]
     NoContent,
     #[response(status = NOT_FOUND, description = "Group not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -384,7 +417,7 @@ pub async fn delete_member(
     Path(path): Path<MemberPath>,
 ) -> DeleteMemberResponse {
     let Ok(group_id) = GroupId::from_str(&path.id) else {
-        return DeleteMemberResponse::NotFound;
+        return DeleteMemberResponse::NotFound(ErrorMessage::not_found());
     };
     let role: DomainRole = (&path.role).into();
     let tx = SqliteTransaction::new(st.pool.clone());
@@ -395,10 +428,12 @@ pub async fn delete_member(
         .await
     {
         Ok(()) => DeleteMemberResponse::NoContent,
-        Err(ApplicationSequentialOperationError::Unauthorized) => DeleteMemberResponse::Forbidden,
-        Err(ApplicationSequentialOperationError::OperationFailed(DeleteError::NotFound)) => {
-            DeleteMemberResponse::NotFound
+        Err(ApplicationSequentialOperationError::Unauthorized) => {
+            DeleteMemberResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(_) => DeleteMemberResponse::InternalServerError,
+        Err(ApplicationSequentialOperationError::OperationFailed(DeleteError::NotFound)) => {
+            DeleteMemberResponse::NotFound(ErrorMessage::not_found())
+        }
+        Err(_) => DeleteMemberResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }

--- a/apps/backend/src/routes/api_v3/notifications/handlers.rs
+++ b/apps/backend/src/routes/api_v3/notifications/handlers.rs
@@ -1,3 +1,4 @@
+use super::super::ErrorMessage;
 use super::super::V3State;
 use super::dto::{NotificationCreate, NotificationRead, NotificationUpdate};
 use crate::application::error::{ApplicationOperationError, DeleteError, UpdateError};
@@ -20,7 +21,7 @@ pub enum GetNotificationsResponse {
     #[response(status = OK)]
     Ok(Vec<NotificationRead>),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -38,7 +39,9 @@ pub async fn get_notifications(
         Ok(notifications) => {
             GetNotificationsResponse::Ok(notifications.iter().map(NotificationRead::from).collect())
         }
-        Err(_) => GetNotificationsResponse::InternalServerError,
+        Err(_) => {
+            GetNotificationsResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }
 
@@ -47,11 +50,11 @@ pub enum PostNotificationResponse {
     #[response(status = CREATED)]
     Created(NotificationRead),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = UNPROCESSABLE_ENTITY, description = "Invalid notification")]
-    UnprocessableEntity,
+    UnprocessableEntity(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -69,7 +72,11 @@ pub async fn post_notification(
 ) -> PostNotificationResponse {
     let ntype = match body.r#type.to_domain() {
         Ok(t) => t,
-        Err(_) => return PostNotificationResponse::UnprocessableEntity,
+        Err(_) => {
+            return PostNotificationResponse::UnprocessableEntity(
+                ErrorMessage::unprocessable_entity(),
+            );
+        }
     };
     match st
         .app
@@ -79,13 +86,19 @@ pub async fn post_notification(
     {
         Ok(id) => match st.app.notification().get_by_id(&actor, id).await {
             Ok(Some(n)) => PostNotificationResponse::Created(NotificationRead::from(&n)),
-            _ => PostNotificationResponse::InternalServerError,
+            _ => {
+                PostNotificationResponse::InternalServerError(ErrorMessage::internal_server_error())
+            }
         },
-        Err(ApplicationOperationError::Unauthorized) => PostNotificationResponse::Forbidden,
-        Err(ApplicationOperationError::InvalidInput(_)) => {
-            PostNotificationResponse::UnprocessableEntity
+        Err(ApplicationOperationError::Unauthorized) => {
+            PostNotificationResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(_) => PostNotificationResponse::InternalServerError,
+        Err(ApplicationOperationError::InvalidInput(_)) => {
+            PostNotificationResponse::UnprocessableEntity(ErrorMessage::unprocessable_entity())
+        }
+        Err(_) => {
+            PostNotificationResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }
 
@@ -94,9 +107,9 @@ pub enum GetNotificationResponse {
     #[response(status = OK, description = "Notification found")]
     Ok(NotificationRead),
     #[response(status = NOT_FOUND, description = "Notification not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -119,8 +132,10 @@ pub async fn get_notification(
         .await
     {
         Ok(Some(n)) => GetNotificationResponse::Ok(NotificationRead::from(&n)),
-        Ok(None) => GetNotificationResponse::NotFound,
-        Err(_) => GetNotificationResponse::InternalServerError,
+        Ok(None) => GetNotificationResponse::NotFound(ErrorMessage::not_found()),
+        Err(_) => {
+            GetNotificationResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }
 
@@ -129,13 +144,13 @@ pub enum PatchNotificationResponse {
     #[response(status = OK, description = "Notification updated")]
     Ok(NotificationRead),
     #[response(status = NOT_FOUND, description = "Notification not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = UNPROCESSABLE_ENTITY, description = "Invalid notification")]
-    UnprocessableEntity,
+    UnprocessableEntity(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -164,14 +179,18 @@ pub async fn patch_notification(
         .await
     {
         Ok(n) => PatchNotificationResponse::Ok(NotificationRead::from(&n)),
-        Err(ApplicationOperationError::Unauthorized) => PatchNotificationResponse::Forbidden,
+        Err(ApplicationOperationError::Unauthorized) => {
+            PatchNotificationResponse::Forbidden(ErrorMessage::forbidden())
+        }
         Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
-            PatchNotificationResponse::NotFound
+            PatchNotificationResponse::NotFound(ErrorMessage::not_found())
         }
         Err(ApplicationOperationError::InvalidInput(_)) => {
-            PatchNotificationResponse::UnprocessableEntity
+            PatchNotificationResponse::UnprocessableEntity(ErrorMessage::unprocessable_entity())
         }
-        Err(_) => PatchNotificationResponse::InternalServerError,
+        Err(_) => {
+            PatchNotificationResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }
 
@@ -180,11 +199,11 @@ pub enum DeleteNotificationResponse {
     #[response(status = NO_CONTENT, description = "Notification deleted")]
     NoContent,
     #[response(status = NOT_FOUND, description = "Notification not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -207,10 +226,14 @@ pub async fn delete_notification(
         .await
     {
         Ok(()) => DeleteNotificationResponse::NoContent,
-        Err(ApplicationOperationError::Unauthorized) => DeleteNotificationResponse::Forbidden,
-        Err(ApplicationOperationError::OperationFailed(DeleteError::NotFound)) => {
-            DeleteNotificationResponse::NotFound
+        Err(ApplicationOperationError::Unauthorized) => {
+            DeleteNotificationResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(_) => DeleteNotificationResponse::InternalServerError,
+        Err(ApplicationOperationError::OperationFailed(DeleteError::NotFound)) => {
+            DeleteNotificationResponse::NotFound(ErrorMessage::not_found())
+        }
+        Err(_) => {
+            DeleteNotificationResponse::InternalServerError(ErrorMessage::internal_server_error())
+        }
     }
 }

--- a/apps/backend/src/routes/api_v3/users/handlers.rs
+++ b/apps/backend/src/routes/api_v3/users/handlers.rs
@@ -1,3 +1,4 @@
+use super::super::ErrorMessage;
 use super::super::V3State;
 use super::super::notifications::NotificationRead;
 use super::dto::{MAddressUpdate, MAddressUpdated, UserCreate, UserCreated, UserRead, UserUpdate};
@@ -18,9 +19,9 @@ pub enum GetUsersResponse {
     #[response(status = OK)]
     Ok(Vec<UserRead>),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -33,8 +34,10 @@ pub enum GetUsersResponse {
 pub async fn get_users(State(st): State<V3State>, actor: ActorContext) -> GetUsersResponse {
     match st.app.user().get_all(&actor).await {
         Ok(users) => GetUsersResponse::Ok(users.iter().map(UserRead::from).collect()),
-        Err(ApplicationOperationError::Unauthorized) => GetUsersResponse::Forbidden,
-        Err(_) => GetUsersResponse::InternalServerError,
+        Err(ApplicationOperationError::Unauthorized) => {
+            GetUsersResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(_) => GetUsersResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -43,13 +46,13 @@ pub enum PostUserResponse {
     #[response(status = CREATED, description = "User created; returns the activation token")]
     Created(UserCreated),
     #[response(status = BAD_REQUEST, description = "Invalid input")]
-    BadRequest,
+    BadRequest(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = CONFLICT, description = "m_address already in use")]
-    Conflict,
+    Conflict(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -67,7 +70,7 @@ pub async fn post_user(
 ) -> PostUserResponse {
     let user_id = UserId::new(Uuid::new_v4());
     let Ok(m_address) = EmailAddress::new(body.m_address) else {
-        return PostUserResponse::BadRequest;
+        return PostUserResponse::BadRequest(ErrorMessage::bad_request());
     };
     match st
         .app
@@ -88,15 +91,21 @@ pub async fn post_user(
                     user: UserRead::from(&user),
                     activation_token: token,
                 }),
-                Err(_) => PostUserResponse::InternalServerError,
+                Err(_) => {
+                    PostUserResponse::InternalServerError(ErrorMessage::internal_server_error())
+                }
             }
         }
-        Err(ApplicationOperationError::Unauthorized) => PostUserResponse::Forbidden,
-        Err(ApplicationOperationError::OperationFailed(InsertError::Conflict)) => {
-            PostUserResponse::Conflict
+        Err(ApplicationOperationError::Unauthorized) => {
+            PostUserResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(ApplicationOperationError::InvalidInput(_)) => PostUserResponse::BadRequest,
-        Err(_) => PostUserResponse::InternalServerError,
+        Err(ApplicationOperationError::OperationFailed(InsertError::Conflict)) => {
+            PostUserResponse::Conflict(ErrorMessage::conflict())
+        }
+        Err(ApplicationOperationError::InvalidInput(_)) => {
+            PostUserResponse::BadRequest(ErrorMessage::bad_request())
+        }
+        Err(_) => PostUserResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -112,11 +121,11 @@ pub enum GetUserResponse {
     #[response(status = OK, description = "User found")]
     Ok(UserRead),
     #[response(status = NOT_FOUND, description = "User not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -136,9 +145,11 @@ pub async fn get_user(
         Ok(Some((u, group))) => {
             GetUserResponse::Ok(UserRead::with_group(&u, group.map(|g| g.to_string())))
         }
-        Ok(None) => GetUserResponse::NotFound,
-        Err(ApplicationOperationError::Unauthorized) => GetUserResponse::Forbidden,
-        Err(_) => GetUserResponse::InternalServerError,
+        Ok(None) => GetUserResponse::NotFound(ErrorMessage::not_found()),
+        Err(ApplicationOperationError::Unauthorized) => {
+            GetUserResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(_) => GetUserResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -151,15 +162,17 @@ pub async fn get_user(
 )]
 pub async fn get_user_me(State(st): State<V3State>, actor: ActorContext) -> GetUserResponse {
     let Some(user_id) = actor.user_id() else {
-        return GetUserResponse::Forbidden;
+        return GetUserResponse::Forbidden(ErrorMessage::forbidden());
     };
     match st.app.user().get_by_id(&actor, user_id).await {
         Ok(Some((u, group))) => {
             GetUserResponse::Ok(UserRead::with_group(&u, group.map(|g| g.to_string())))
         }
-        Ok(None) => GetUserResponse::NotFound,
-        Err(ApplicationOperationError::Unauthorized) => GetUserResponse::Forbidden,
-        Err(_) => GetUserResponse::InternalServerError,
+        Ok(None) => GetUserResponse::NotFound(ErrorMessage::not_found()),
+        Err(ApplicationOperationError::Unauthorized) => {
+            GetUserResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(_) => GetUserResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -168,13 +181,13 @@ pub enum PatchUserResponse {
     #[response(status = OK, description = "User updated")]
     Ok(UserRead),
     #[response(status = BAD_REQUEST, description = "Invalid input")]
-    BadRequest,
+    BadRequest(ErrorMessage),
     #[response(status = NOT_FOUND, description = "User not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -200,12 +213,16 @@ pub async fn patch_user(
         .await
     {
         Ok(u) => PatchUserResponse::Ok(UserRead::from(&u)),
-        Err(ApplicationOperationError::Unauthorized) => PatchUserResponse::Forbidden,
-        Err(ApplicationOperationError::InvalidInput(_)) => PatchUserResponse::BadRequest,
-        Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
-            PatchUserResponse::NotFound
+        Err(ApplicationOperationError::Unauthorized) => {
+            PatchUserResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(_) => PatchUserResponse::InternalServerError,
+        Err(ApplicationOperationError::InvalidInput(_)) => {
+            PatchUserResponse::BadRequest(ErrorMessage::bad_request())
+        }
+        Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
+            PatchUserResponse::NotFound(ErrorMessage::not_found())
+        }
+        Err(_) => PatchUserResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -214,11 +231,11 @@ pub enum DeleteUserResponse {
     #[response(status = NO_CONTENT, description = "User deleted")]
     NoContent,
     #[response(status = NOT_FOUND, description = "User not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -236,11 +253,13 @@ pub async fn delete_user(
 ) -> DeleteUserResponse {
     match st.app.user().delete_user(&actor, path.id).await {
         Ok(()) => DeleteUserResponse::NoContent,
-        Err(ApplicationOperationError::Unauthorized) => DeleteUserResponse::Forbidden,
-        Err(ApplicationOperationError::OperationFailed(DeleteError::NotFound)) => {
-            DeleteUserResponse::NotFound
+        Err(ApplicationOperationError::Unauthorized) => {
+            DeleteUserResponse::Forbidden(ErrorMessage::forbidden())
         }
-        Err(_) => DeleteUserResponse::InternalServerError,
+        Err(ApplicationOperationError::OperationFailed(DeleteError::NotFound)) => {
+            DeleteUserResponse::NotFound(ErrorMessage::not_found())
+        }
+        Err(_) => DeleteUserResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }
 
@@ -249,11 +268,11 @@ pub enum GetUserReadNotificationsResponse {
     #[response(status = OK)]
     Ok(Vec<NotificationRead>),
     #[response(status = NOT_FOUND, description = "User not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -273,13 +292,21 @@ pub async fn get_user_read_notifications(
     // 対象ユーザーの存在確認(authz は介在しない)。
     match st.app.find_user_for_auth(user_id).await {
         Ok(Some(_)) => {}
-        Ok(None) => return GetUserReadNotificationsResponse::NotFound,
-        Err(_) => return GetUserReadNotificationsResponse::InternalServerError,
+        Ok(None) => return GetUserReadNotificationsResponse::NotFound(ErrorMessage::not_found()),
+        Err(_) => {
+            return GetUserReadNotificationsResponse::InternalServerError(
+                ErrorMessage::internal_server_error(),
+            );
+        }
     }
     // 対象ユーザーの認可コンテキスト(所属が無ければ None)。
     let target_ctx = match st.app.build_actor_context(user_id).await {
         Ok(c) => c,
-        Err(_) => return GetUserReadNotificationsResponse::InternalServerError,
+        Err(_) => {
+            return GetUserReadNotificationsResponse::InternalServerError(
+                ErrorMessage::internal_server_error(),
+            );
+        }
     };
     match st
         .app
@@ -295,8 +322,12 @@ pub async fn get_user_read_notifications(
                 .map(|(n, _)| NotificationRead::from(&n))
                 .collect(),
         ),
-        Err(ApplicationOperationError::Unauthorized) => GetUserReadNotificationsResponse::Forbidden,
-        Err(_) => GetUserReadNotificationsResponse::InternalServerError,
+        Err(ApplicationOperationError::Unauthorized) => {
+            GetUserReadNotificationsResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(_) => GetUserReadNotificationsResponse::InternalServerError(
+            ErrorMessage::internal_server_error(),
+        ),
     }
 }
 
@@ -305,13 +336,13 @@ pub enum PostUserMAddressResponse {
     #[response(status = OK, description = "m_address changed; returns a new activation token")]
     Ok(MAddressUpdated),
     #[response(status = BAD_REQUEST, description = "Invalid input")]
-    BadRequest,
+    BadRequest(ErrorMessage),
     #[response(status = NOT_FOUND, description = "User not found")]
-    NotFound,
+    NotFound(ErrorMessage),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -331,7 +362,7 @@ pub async fn post_user_m_address(
 ) -> PostUserMAddressResponse {
     let user_id = path.id;
     let Ok(m_address) = EmailAddress::new(body.m_address) else {
-        return PostUserMAddressResponse::BadRequest;
+        return PostUserMAddressResponse::BadRequest(ErrorMessage::new("Invalid email address"));
     };
     match st
         .app
@@ -351,13 +382,19 @@ pub async fn post_user_m_address(
                 Ok(token) => PostUserMAddressResponse::Ok(MAddressUpdated {
                     activation_token: token,
                 }),
-                Err(_) => PostUserMAddressResponse::InternalServerError,
+                Err(_) => PostUserMAddressResponse::InternalServerError(ErrorMessage::new(
+                    "Internal server error",
+                )),
             }
         }
-        Err(ApplicationOperationError::Unauthorized) => PostUserMAddressResponse::Forbidden,
-        Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
-            PostUserMAddressResponse::NotFound
+        Err(ApplicationOperationError::Unauthorized) => {
+            PostUserMAddressResponse::Forbidden(ErrorMessage::new("Forbidden"))
         }
-        Err(_) => PostUserMAddressResponse::InternalServerError,
+        Err(ApplicationOperationError::OperationFailed(UpdateError::NotFound)) => {
+            PostUserMAddressResponse::NotFound(ErrorMessage::new("User not found"))
+        }
+        Err(_) => PostUserMAddressResponse::InternalServerError(ErrorMessage::new(
+            "Internal server error",
+        )),
     }
 }

--- a/apps/backend/src/routes/api_v3/util/handlers.rs
+++ b/apps/backend/src/routes/api_v3/util/handlers.rs
@@ -1,3 +1,4 @@
+use super::super::ErrorMessage;
 use super::dto::MetaInfo;
 use crate::application::error::ApplicationError;
 use crate::domain::actor_ctx::ActorContext;
@@ -19,9 +20,9 @@ pub enum GetMetaResponse {
     #[response(status = OK, description = "Returns the page title and description")]
     Ok(MetaInfo),
     #[response(status = FORBIDDEN, description = "Forbidden")]
-    Forbidden,
+    Forbidden(ErrorMessage),
     #[response(status = INTERNAL_SERVER_ERROR, description = "Internal server error")]
-    InternalServerError,
+    InternalServerError(ErrorMessage),
 }
 
 #[utoipa::path(
@@ -39,7 +40,9 @@ pub async fn get_meta(
 ) -> GetMetaResponse {
     match st.app.meta().get_meta(&actor, &query.url).await {
         Ok(pm) => GetMetaResponse::Ok(MetaInfo::from(pm)),
-        Err(ApplicationError::Unauthorized) => GetMetaResponse::Forbidden,
-        Err(_) => GetMetaResponse::InternalServerError,
+        Err(ApplicationError::Unauthorized) => {
+            GetMetaResponse::Forbidden(ErrorMessage::forbidden())
+        }
+        Err(_) => GetMetaResponse::InternalServerError(ErrorMessage::internal_server_error()),
     }
 }

--- a/docs/api/api_v3/openapi.json
+++ b/docs/api/api_v3/openapi.json
@@ -7,7 +7,9 @@
   "paths": {
     "/approval-requests": {
       "get": {
-        "tags": ["approval-requests"],
+        "tags": [
+          "approval-requests"
+        ],
         "description": "Get all approval requests, optionally filtered by group.",
         "operationId": "get_approval_requests",
         "parameters": [
@@ -36,15 +38,31 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "post": {
-        "tags": ["approval-requests"],
+        "tags": [
+          "approval-requests"
+        ],
         "description": "Create an approval request.",
         "operationId": "post_approval_request",
         "requestBody": {
@@ -69,20 +87,43 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Invalid approval request"
+            "description": "Invalid approval request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/approval-requests/{id}": {
       "get": {
-        "tags": ["approval-requests"],
+        "tags": [
+          "approval-requests"
+        ],
         "description": "Get an approval request by id.",
         "operationId": "get_approval_request",
         "parameters": [
@@ -108,18 +149,41 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Approval request not found"
+            "description": "Approval request not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "delete": {
-        "tags": ["approval-requests"],
+        "tags": [
+          "approval-requests"
+        ],
         "description": "Delete an approval request by id.",
         "operationId": "delete_approval_request",
         "parameters": [
@@ -138,20 +202,43 @@
             "description": "Approval request deleted"
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Approval request not found"
+            "description": "Approval request not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/approval-requests/{id}/approve": {
       "post": {
-        "tags": ["approval-requests"],
+        "tags": [
+          "approval-requests"
+        ],
         "description": "Approve an approval request by id.",
         "operationId": "approve_approval_request",
         "parameters": [
@@ -187,23 +274,53 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Approval request not found"
+            "description": "Approval request not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "409": {
-            "description": "Approval request is not pending"
+            "description": "Approval request is not pending",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/approval-requests/{id}/close": {
       "post": {
-        "tags": ["approval-requests"],
+        "tags": [
+          "approval-requests"
+        ],
         "description": "Close an approval request by id.",
         "operationId": "close_approval_request",
         "parameters": [
@@ -229,23 +346,53 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Approval request not found"
+            "description": "Approval request not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "409": {
-            "description": "Approval request is not pending"
+            "description": "Approval request is not pending",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/approval-requests/{id}/reject": {
       "post": {
-        "tags": ["approval-requests"],
+        "tags": [
+          "approval-requests"
+        ],
         "description": "Reject an approval request by id.",
         "operationId": "reject_approval_request",
         "parameters": [
@@ -281,23 +428,53 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Approval request not found"
+            "description": "Approval request not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "409": {
-            "description": "Approval request is not pending"
+            "description": "Approval request is not pending",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/document-categories": {
       "get": {
-        "tags": ["document-categories"],
+        "tags": [
+          "document-categories"
+        ],
         "description": "Get all document categories.",
         "operationId": "get_document_categories",
         "responses": {
@@ -315,15 +492,31 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "post": {
-        "tags": ["document-categories"],
+        "tags": [
+          "document-categories"
+        ],
         "description": "Create a document category.",
         "operationId": "post_document_category",
         "requestBody": {
@@ -348,20 +541,43 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Invalid document category"
+            "description": "Invalid document category",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/document-categories/{id}": {
       "get": {
-        "tags": ["document-categories"],
+        "tags": [
+          "document-categories"
+        ],
         "description": "Get a document category by id.",
         "operationId": "get_document_category",
         "parameters": [
@@ -387,18 +603,41 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Document category not found"
+            "description": "Document category not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "delete": {
-        "tags": ["document-categories"],
+        "tags": [
+          "document-categories"
+        ],
         "description": "Delete a document category by id.",
         "operationId": "delete_document_category",
         "parameters": [
@@ -417,18 +656,41 @@
             "description": "Document category deleted"
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Document category not found"
+            "description": "Document category not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "patch": {
-        "tags": ["document-categories"],
+        "tags": [
+          "document-categories"
+        ],
         "description": "Edit a document category by id.",
         "operationId": "patch_document_category",
         "parameters": [
@@ -464,23 +726,53 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Document category not found"
+            "description": "Document category not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Invalid document category"
+            "description": "Invalid document category",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/documents": {
       "get": {
-        "tags": ["documents"],
+        "tags": [
+          "documents"
+        ],
         "description": "Get all documents visible to the caller.",
         "operationId": "get_documents",
         "parameters": [
@@ -509,12 +801,21 @@
             }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "post": {
-        "tags": ["documents"],
+        "tags": [
+          "documents"
+        ],
         "description": "Create a document.",
         "operationId": "post_document",
         "requestBody": {
@@ -539,20 +840,43 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Invalid document"
+            "description": "Invalid document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/documents/by-category": {
       "get": {
-        "tags": ["documents"],
+        "tags": [
+          "documents"
+        ],
         "description": "Get documents visible to the caller, grouped by category.",
         "operationId": "get_documents_by_category",
         "parameters": [
@@ -581,14 +905,23 @@
             }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/documents/{id}": {
       "get": {
-        "tags": ["documents"],
+        "tags": [
+          "documents"
+        ],
         "description": "Get a document by id.",
         "operationId": "get_document",
         "parameters": [
@@ -614,15 +947,31 @@
             }
           },
           "404": {
-            "description": "Document not found"
+            "description": "Document not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "delete": {
-        "tags": ["documents"],
+        "tags": [
+          "documents"
+        ],
         "description": "Delete a document by id.",
         "operationId": "delete_document",
         "parameters": [
@@ -641,18 +990,41 @@
             "description": "Document deleted"
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Document not found"
+            "description": "Document not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "patch": {
-        "tags": ["documents"],
+        "tags": [
+          "documents"
+        ],
         "description": "Edit a document by id.",
         "operationId": "patch_document",
         "parameters": [
@@ -688,23 +1060,53 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Document not found"
+            "description": "Document not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Invalid document"
+            "description": "Invalid document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/files/download": {
       "get": {
-        "tags": ["files"],
+        "tags": [
+          "files"
+        ],
         "description": "Issue a presigned URL for downloading a file.",
         "operationId": "get_file_download",
         "parameters": [
@@ -749,17 +1151,33 @@
             "description": "Redirect to the presigned URL (when redirect=true)"
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/files/upload": {
       "post": {
-        "tags": ["files"],
+        "tags": [
+          "files"
+        ],
         "description": "Issue a presigned URL for uploading a file.",
         "operationId": "post_file_upload",
         "requestBody": {
@@ -784,17 +1202,33 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/forms": {
       "get": {
-        "tags": ["forms"],
+        "tags": [
+          "forms"
+        ],
         "description": "Get all forms visible to the caller.",
         "operationId": "get_forms",
         "responses": {
@@ -812,12 +1246,21 @@
             }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "post": {
-        "tags": ["forms"],
+        "tags": [
+          "forms"
+        ],
         "description": "Create a form.",
         "operationId": "post_form",
         "requestBody": {
@@ -842,20 +1285,43 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Invalid form"
+            "description": "Invalid form",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/forms/{id}": {
       "get": {
-        "tags": ["forms"],
+        "tags": [
+          "forms"
+        ],
         "description": "Get a form by id.",
         "operationId": "get_form",
         "parameters": [
@@ -881,15 +1347,31 @@
             }
           },
           "404": {
-            "description": "Form not found"
+            "description": "Form not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "delete": {
-        "tags": ["forms"],
+        "tags": [
+          "forms"
+        ],
         "description": "Delete a form by id.",
         "operationId": "delete_form",
         "parameters": [
@@ -908,18 +1390,41 @@
             "description": "Form deleted"
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Form not found"
+            "description": "Form not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "patch": {
-        "tags": ["forms"],
+        "tags": [
+          "forms"
+        ],
         "description": "Edit a form by id.",
         "operationId": "patch_form",
         "parameters": [
@@ -955,23 +1460,53 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Form not found"
+            "description": "Form not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Invalid form"
+            "description": "Invalid form",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/groups": {
       "get": {
-        "tags": ["groups"],
+        "tags": [
+          "groups"
+        ],
         "description": "Get all groups.",
         "operationId": "get_groups",
         "responses": {
@@ -989,17 +1524,33 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/groups/us": {
       "get": {
-        "tags": ["groups"],
+        "tags": [
+          "groups"
+        ],
         "description": "Get the group the current user belongs to.",
         "operationId": "get_group_us",
         "responses": {
@@ -1014,20 +1565,43 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Group not found"
+            "description": "Group not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/groups/{id}": {
       "get": {
-        "tags": ["groups"],
+        "tags": [
+          "groups"
+        ],
         "description": "Get a group by id.",
         "operationId": "get_group",
         "parameters": [
@@ -1052,18 +1626,41 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Group not found"
+            "description": "Group not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "put": {
-        "tags": ["groups"],
+        "tags": [
+          "groups"
+        ],
         "description": "Create a group by id or replace an existing one.",
         "operationId": "put_group",
         "parameters": [
@@ -1108,18 +1705,41 @@
             }
           },
           "400": {
-            "description": "Invalid group id or input"
+            "description": "Invalid group id or input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "delete": {
-        "tags": ["groups"],
+        "tags": [
+          "groups"
+        ],
         "description": "Delete a group by id.",
         "operationId": "delete_group",
         "parameters": [
@@ -1137,18 +1757,41 @@
             "description": "Group deleted"
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Group not found"
+            "description": "Group not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "patch": {
-        "tags": ["groups"],
+        "tags": [
+          "groups"
+        ],
         "description": "Edit a group by id.",
         "operationId": "patch_group",
         "parameters": [
@@ -1183,23 +1826,53 @@
             }
           },
           "400": {
-            "description": "Invalid input"
+            "description": "Invalid input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Group not found"
+            "description": "Group not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/groups/{id}/members": {
       "get": {
-        "tags": ["groups"],
+        "tags": [
+          "groups"
+        ],
         "description": "Get all members of a group.",
         "operationId": "get_members",
         "parameters": [
@@ -1227,20 +1900,43 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Group not found"
+            "description": "Group not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/groups/{id}/members/{role}": {
       "put": {
-        "tags": ["groups"],
+        "tags": [
+          "groups"
+        ],
         "description": "Assign a member to a role in a group or replace an existing one.",
         "operationId": "put_member",
         "parameters": [
@@ -1293,21 +1989,51 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Group not found"
+            "description": "Group not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Invalid for group type"
+            "description": "Invalid for group type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "delete": {
-        "tags": ["groups"],
+        "tags": [
+          "groups"
+        ],
         "description": "Remove a member from a role in a group.",
         "operationId": "delete_member",
         "parameters": [
@@ -1333,20 +2059,43 @@
             "description": "Member deleted"
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Group not found"
+            "description": "Group not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/notifications": {
       "get": {
-        "tags": ["notifications"],
+        "tags": [
+          "notifications"
+        ],
         "description": "Get all notifications visible to the caller.",
         "operationId": "get_notifications",
         "responses": {
@@ -1364,12 +2113,21 @@
             }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "post": {
-        "tags": ["notifications"],
+        "tags": [
+          "notifications"
+        ],
         "description": "Create a notification.",
         "operationId": "post_notification",
         "requestBody": {
@@ -1394,20 +2152,43 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Invalid notification"
+            "description": "Invalid notification",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/notifications/{id}": {
       "get": {
-        "tags": ["notifications"],
+        "tags": [
+          "notifications"
+        ],
         "description": "Get a notification by id.",
         "operationId": "get_notification",
         "parameters": [
@@ -1433,15 +2214,31 @@
             }
           },
           "404": {
-            "description": "Notification not found"
+            "description": "Notification not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "delete": {
-        "tags": ["notifications"],
+        "tags": [
+          "notifications"
+        ],
         "description": "Delete a notification by id.",
         "operationId": "delete_notification",
         "parameters": [
@@ -1460,18 +2257,41 @@
             "description": "Notification deleted"
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Notification not found"
+            "description": "Notification not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "patch": {
-        "tags": ["notifications"],
+        "tags": [
+          "notifications"
+        ],
         "description": "Edit a notification by id.",
         "operationId": "patch_notification",
         "parameters": [
@@ -1507,23 +2327,53 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Notification not found"
+            "description": "Notification not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "422": {
-            "description": "Invalid notification"
+            "description": "Invalid notification",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/users": {
       "get": {
-        "tags": ["users"],
+        "tags": [
+          "users"
+        ],
         "description": "Get all users.",
         "operationId": "get_users",
         "responses": {
@@ -1541,15 +2391,31 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "post": {
-        "tags": ["users"],
+        "tags": [
+          "users"
+        ],
         "description": "Create a new user (id is generated server-side); returns the activation token.",
         "operationId": "post_user",
         "requestBody": {
@@ -1574,23 +2440,53 @@
             }
           },
           "400": {
-            "description": "Invalid input"
+            "description": "Invalid input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "409": {
-            "description": "m_address already in use"
+            "description": "m_address already in use",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/users/me": {
       "get": {
-        "tags": ["users"],
+        "tags": [
+          "users"
+        ],
         "description": "Get the currently authenticated user.",
         "operationId": "get_user_me",
         "responses": {
@@ -1605,20 +2501,43 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "User not found"
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/users/{id}": {
       "get": {
-        "tags": ["users"],
+        "tags": [
+          "users"
+        ],
         "description": "Get a user by id.",
         "operationId": "get_user",
         "parameters": [
@@ -1644,18 +2563,41 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "User not found"
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "delete": {
-        "tags": ["users"],
+        "tags": [
+          "users"
+        ],
         "description": "Delete a user by id.",
         "operationId": "delete_user",
         "parameters": [
@@ -1674,18 +2616,41 @@
             "description": "User deleted"
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "User not found"
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       },
       "patch": {
-        "tags": ["users"],
+        "tags": [
+          "users"
+        ],
         "description": "Edit a user's name by id (m_address is changed via its own endpoint).",
         "operationId": "patch_user",
         "parameters": [
@@ -1721,23 +2686,53 @@
             }
           },
           "400": {
-            "description": "Invalid input"
+            "description": "Invalid input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "User not found"
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/users/{id}/m_address": {
       "post": {
-        "tags": ["users"],
+        "tags": [
+          "users"
+        ],
         "description": "Change a user's m_address and re-issue an activation token.",
         "operationId": "post_user_m_address",
         "parameters": [
@@ -1773,23 +2768,53 @@
             }
           },
           "400": {
-            "description": "Invalid input"
+            "description": "Invalid input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "User not found"
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/users/{id}/read-notifications": {
       "get": {
-        "tags": ["users"],
+        "tags": [
+          "users"
+        ],
         "description": "Get the notifications the user has marked as read.",
         "operationId": "get_user_read_notifications",
         "parameters": [
@@ -1818,20 +2843,43 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "404": {
-            "description": "User not found"
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
     },
     "/util/meta": {
       "get": {
-        "tags": ["util"],
+        "tags": [
+          "util"
+        ],
         "description": "Fetch OpenGraph/HTML metadata (title, description) for a URL.",
         "operationId": "get_meta",
         "parameters": [
@@ -1857,10 +2905,24 @@
             }
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
           }
         }
       }
@@ -1872,7 +2934,10 @@
         "type": "object",
         "properties": {
           "reason": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -1883,7 +2948,9 @@
           },
           {
             "type": "object",
-            "required": ["issue_reason"],
+            "required": [
+              "issue_reason"
+            ],
             "properties": {
               "issue_reason": {
                 "type": "string"
@@ -1902,7 +2969,12 @@
           },
           {
             "type": "object",
-            "required": ["id", "issued_at", "issued_by", "issue_reason"],
+            "required": [
+              "id",
+              "issued_at",
+              "issued_by",
+              "issue_reason"
+            ],
             "properties": {
               "id": {
                 "type": "string",
@@ -1927,20 +2999,31 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["status"],
+            "required": [
+              "status"
+            ],
             "properties": {
               "status": {
                 "type": "string",
-                "enum": ["pending"]
+                "enum": [
+                  "pending"
+                ]
               }
             }
           },
           {
             "type": "object",
-            "required": ["approved_by", "approved_at", "status"],
+            "required": [
+              "approved_by",
+              "approved_at",
+              "status"
+            ],
             "properties": {
               "approval_reason": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "approved_at": {
                 "type": "string",
@@ -1952,13 +3035,19 @@
               },
               "status": {
                 "type": "string",
-                "enum": ["approved"]
+                "enum": [
+                  "approved"
+                ]
               }
             }
           },
           {
             "type": "object",
-            "required": ["rejected_by", "rejected_at", "status"],
+            "required": [
+              "rejected_by",
+              "rejected_at",
+              "status"
+            ],
             "properties": {
               "rejected_at": {
                 "type": "string",
@@ -1969,17 +3058,25 @@
                 "format": "uuid"
               },
               "rejection_reason": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "status": {
                 "type": "string",
-                "enum": ["rejected"]
+                "enum": [
+                  "rejected"
+                ]
               }
             }
           },
           {
             "type": "object",
-            "required": ["closed_at", "status"],
+            "required": [
+              "closed_at",
+              "status"
+            ],
             "properties": {
               "closed_at": {
                 "type": "string",
@@ -1987,7 +3084,9 @@
               },
               "status": {
                 "type": "string",
-                "enum": ["closed"]
+                "enum": [
+                  "closed"
+                ]
               }
             }
           }
@@ -1997,17 +3096,27 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
               "description": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "icon_key": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "type": {
                 "type": "string",
-                "enum": ["edit_exhibition_info"]
+                "enum": [
+                  "edit_exhibition_info"
+                ]
               }
             }
           }
@@ -2015,10 +3124,15 @@
       },
       "DocumentCategoryCreate": {
         "type": "object",
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "properties": {
           "emoji": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "title": {
             "type": "string"
@@ -2027,14 +3141,22 @@
       },
       "DocumentCategoryRead": {
         "type": "object",
-        "required": ["id", "created_at", "updated_at", "title"],
+        "required": [
+          "id",
+          "created_at",
+          "updated_at",
+          "title"
+        ],
         "properties": {
           "created_at": {
             "type": "string",
             "format": "date-time"
           },
           "emoji": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "type": "string",
@@ -2053,10 +3175,16 @@
         "type": "object",
         "properties": {
           "emoji": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "title": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -2067,10 +3195,16 @@
           },
           {
             "type": "object",
-            "required": ["title", "targets"],
+            "required": [
+              "title",
+              "targets"
+            ],
             "properties": {
               "category": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "format": "uuid"
               },
               "targets": {
@@ -2090,20 +3224,29 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["content", "format"],
+            "required": [
+              "content",
+              "format"
+            ],
             "properties": {
               "content": {
                 "type": "string"
               },
               "format": {
                 "type": "string",
-                "enum": ["markdown"]
+                "enum": [
+                  "markdown"
+                ]
               }
             }
           },
           {
             "type": "object",
-            "required": ["file_key", "file_name", "format"],
+            "required": [
+              "file_key",
+              "file_name",
+              "format"
+            ],
             "properties": {
               "file_key": {
                 "type": "string"
@@ -2113,13 +3256,19 @@
               },
               "format": {
                 "type": "string",
-                "enum": ["pdf"]
+                "enum": [
+                  "pdf"
+                ]
               }
             }
           },
           {
             "type": "object",
-            "required": ["file_key", "file_name", "format"],
+            "required": [
+              "file_key",
+              "file_name",
+              "format"
+            ],
             "properties": {
               "file_key": {
                 "type": "string"
@@ -2129,7 +3278,9 @@
               },
               "format": {
                 "type": "string",
-                "enum": ["misc"]
+                "enum": [
+                  "misc"
+                ]
               }
             }
           }
@@ -2152,7 +3303,10 @@
             ],
             "properties": {
               "category": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "format": "uuid"
               },
               "created_at": {
@@ -2188,7 +3342,10 @@
         "type": "object",
         "properties": {
           "category": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "uuid"
           },
           "format": {
@@ -2202,20 +3359,28 @@
             ]
           },
           "targets": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "type": "string"
             }
           },
           "title": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
       "DocumentsByCategoryEntry": {
         "type": "object",
         "description": "`GET /documents/by-category` の 1 カテゴリ分のエントリ。\n`category` が `None` のときは未分類ドキュメントを表す。",
-        "required": ["documents"],
+        "required": [
+          "documents"
+        ],
         "properties": {
           "category": {
             "oneOf": [
@@ -2235,10 +3400,23 @@
           }
         }
       },
+      "ErrorMessage": {
+        "type": "object",
+        "required": [
+          "message"
+        ],
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        }
+      },
       "FileDownloadResponse": {
         "type": "object",
         "description": "ダウンロード用に発行した presigned URL。",
-        "required": ["presigned_url"],
+        "required": [
+          "presigned_url"
+        ],
         "properties": {
           "presigned_url": {
             "type": "string"
@@ -2248,7 +3426,9 @@
       "FileUploadRequest": {
         "type": "object",
         "description": "アップロード用 presigned URL のリクエストボディ。",
-        "required": ["file_name"],
+        "required": [
+          "file_name"
+        ],
         "properties": {
           "file_name": {
             "type": "string"
@@ -2258,7 +3438,10 @@
       "FileUploadResponse": {
         "type": "object",
         "description": "アップロード用に発行した presigned URL とストレージキー。",
-        "required": ["presigned_url", "key"],
+        "required": [
+          "presigned_url",
+          "key"
+        ],
         "properties": {
           "key": {
             "type": "string"
@@ -2275,7 +3458,12 @@
           },
           {
             "type": "object",
-            "required": ["targets", "name", "summary", "due_date"],
+            "required": [
+              "targets",
+              "name",
+              "summary",
+              "due_date"
+            ],
             "properties": {
               "due_date": {
                 "type": "string",
@@ -2319,7 +3507,10 @@
                 "format": "date-time"
               },
               "created_by": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "format": "uuid"
               },
               "due_date": {
@@ -2354,14 +3545,19 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["form_url", "type"],
+            "required": [
+              "form_url",
+              "type"
+            ],
             "properties": {
               "form_url": {
                 "type": "string"
               },
               "type": {
                 "type": "string",
-                "enum": ["external"]
+                "enum": [
+                  "external"
+                ]
               }
             }
           }
@@ -2371,17 +3567,29 @@
         "type": "object",
         "properties": {
           "due_date": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time"
           },
           "name": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "summary": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "targets": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "type": "string"
             }
@@ -2390,7 +3598,10 @@
       },
       "GroupCreate": {
         "type": "object",
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -2402,7 +3613,13 @@
       },
       "GroupRead": {
         "type": "object",
-        "required": ["id", "created_at", "updated_at", "name", "type"],
+        "required": [
+          "id",
+          "created_at",
+          "updated_at",
+          "name",
+          "type"
+        ],
         "properties": {
           "created_at": {
             "type": "string",
@@ -2437,14 +3654,19 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
       "MAddressUpdate": {
         "type": "object",
         "description": "`POST /users/{id}/m_address` のリクエストボディ。",
-        "required": ["m_address"],
+        "required": [
+          "m_address"
+        ],
         "properties": {
           "m_address": {
             "type": "string"
@@ -2454,7 +3676,9 @@
       "MAddressUpdated": {
         "type": "object",
         "description": "m アドレス変更時に再発行される activation token を含むレスポンス。",
-        "required": ["activation_token"],
+        "required": [
+          "activation_token"
+        ],
         "properties": {
           "activation_token": {
             "type": "string"
@@ -2463,7 +3687,9 @@
       },
       "MemberCreate": {
         "type": "object",
-        "required": ["user_id"],
+        "required": [
+          "user_id"
+        ],
         "properties": {
           "user_id": {
             "type": "string",
@@ -2473,7 +3699,11 @@
       },
       "MemberRead": {
         "type": "object",
-        "required": ["user_id", "role", "created_at"],
+        "required": [
+          "user_id",
+          "role",
+          "created_at"
+        ],
         "properties": {
           "created_at": {
             "type": "string",
@@ -2493,10 +3723,16 @@
         "description": "取得先 URL の OpenGraph / HTML メタ情報（リンクプレビュー用）。",
         "properties": {
           "description": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "title": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -2507,7 +3743,9 @@
           },
           {
             "type": "object",
-            "required": ["targets"],
+            "required": [
+              "targets"
+            ],
             "properties": {
               "targets": {
                 "type": "array",
@@ -2526,14 +3764,22 @@
           },
           {
             "type": "object",
-            "required": ["id", "created_at", "updated_at", "targets"],
+            "required": [
+              "id",
+              "created_at",
+              "updated_at",
+              "targets"
+            ],
             "properties": {
               "created_at": {
                 "type": "string",
                 "format": "date-time"
               },
               "created_by": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "format": "uuid"
               },
               "id": {
@@ -2558,7 +3804,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["title", "content", "type"],
+            "required": [
+              "title",
+              "content",
+              "type"
+            ],
             "properties": {
               "content": {
                 "type": "string"
@@ -2568,13 +3818,18 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["markdown"]
+                "enum": [
+                  "markdown"
+                ]
               }
             }
           },
           {
             "type": "object",
-            "required": ["approval_request_id", "type"],
+            "required": [
+              "approval_request_id",
+              "type"
+            ],
             "properties": {
               "approval_request_id": {
                 "type": "string",
@@ -2582,7 +3837,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["approval_request"]
+                "enum": [
+                  "approval_request"
+                ]
               }
             }
           }
@@ -2592,16 +3849,25 @@
         "type": "object",
         "properties": {
           "content": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "targets": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "type": "string"
             }
           },
           "title": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -2617,7 +3883,10 @@
       },
       "UserCreate": {
         "type": "object",
-        "required": ["name", "m_address"],
+        "required": [
+          "name",
+          "m_address"
+        ],
         "properties": {
           "m_address": {
             "type": "string"
@@ -2634,7 +3903,9 @@
           },
           {
             "type": "object",
-            "required": ["activation_token"],
+            "required": [
+              "activation_token"
+            ],
             "properties": {
               "activation_token": {
                 "type": "string"
@@ -2651,14 +3922,23 @@
           },
           {
             "type": "object",
-            "required": ["id", "created_at", "updated_at", "name", "m_address"],
+            "required": [
+              "id",
+              "created_at",
+              "updated_at",
+              "name",
+              "m_address"
+            ],
             "properties": {
               "created_at": {
                 "type": "string",
                 "format": "date-time"
               },
               "group_id": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "description": "所属する代表グループ ID(`\"G-001\"` 形式)。単体取得時のみ付与され、\n一覧/作成/更新では省略される(所属が無い場合も省略)。"
               },
               "id": {
@@ -2683,27 +3963,39 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["status"],
+            "required": [
+              "status"
+            ],
             "properties": {
               "status": {
                 "type": "string",
-                "enum": ["registered"]
+                "enum": [
+                  "registered"
+                ]
               }
             }
           },
           {
             "type": "object",
-            "required": ["status"],
+            "required": [
+              "status"
+            ],
             "properties": {
               "status": {
                 "type": "string",
-                "enum": ["active"]
+                "enum": [
+                  "active"
+                ]
               }
             }
           },
           {
             "type": "object",
-            "required": ["deactivated_at", "reason", "status"],
+            "required": [
+              "deactivated_at",
+              "reason",
+              "status"
+            ],
             "properties": {
               "deactivated_at": {
                 "type": "string",
@@ -2714,7 +4006,9 @@
               },
               "status": {
                 "type": "string",
-                "enum": ["deactivated"]
+                "enum": [
+                  "deactivated"
+                ]
               }
             }
           }
@@ -2726,7 +4020,10 @@
         "description": "`PATCH /users/{id}` のリクエストボディ。氏名のみ変更可能\n(m アドレス変更は専用エンドポイント `POST /users/{id}/m_address`)。",
         "properties": {
           "name": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       }

--- a/libs/shared-types/src/api_v3.d.ts
+++ b/libs/shared-types/src/api_v3.d.ts
@@ -657,6 +657,9 @@ export interface components {
       summary?: string | null;
       targets?: string[] | null;
     };
+    ErrorMessage: {
+      message: string;
+    };
     GroupCreate: {
       name: string;
       type: components['schemas']['GroupType'];
@@ -832,14 +835,18 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -869,21 +876,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Invalid approval request */
       422: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -912,21 +925,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Approval request not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -953,21 +972,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Approval request not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1000,28 +1025,36 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Approval request not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Approval request is not pending */
       409: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1050,28 +1083,36 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Approval request not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Approval request is not pending */
       409: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1104,28 +1145,36 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Approval request not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Approval request is not pending */
       409: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1151,14 +1200,18 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1188,21 +1241,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Invalid document category */
       422: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1231,21 +1290,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Document category not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1272,21 +1337,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Document category not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1319,28 +1390,36 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Document category not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Invalid document category */
       422: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1368,7 +1447,9 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1398,21 +1479,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Invalid document */
       422: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1441,7 +1528,9 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1470,14 +1559,18 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1504,21 +1597,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Document not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1551,28 +1650,36 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Document not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Invalid document */
       422: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1611,14 +1718,18 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1649,14 +1760,18 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1682,7 +1797,9 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1712,21 +1829,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Invalid form */
       422: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1755,14 +1878,18 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1789,21 +1916,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Form not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1836,28 +1969,36 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Form not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Invalid form */
       422: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1883,14 +2024,18 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1917,21 +2062,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Group not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -1960,21 +2111,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Group not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2015,21 +2172,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Forbidden */
       403: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2056,21 +2219,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Group not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2103,28 +2272,36 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Forbidden */
       403: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Group not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2152,21 +2329,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Group not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2208,28 +2391,36 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Group not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Invalid for group type */
       422: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2257,21 +2448,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Group not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2297,7 +2494,9 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2327,21 +2526,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Invalid notification */
       422: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2370,14 +2575,18 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2404,21 +2613,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Notification not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2451,28 +2666,36 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Notification not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Invalid notification */
       422: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2498,14 +2721,18 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2536,28 +2763,36 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Forbidden */
       403: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description m_address already in use */
       409: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2584,21 +2819,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description User not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2627,21 +2868,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description User not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2668,21 +2915,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description User not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2715,28 +2968,36 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Forbidden */
       403: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description User not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2769,28 +3030,36 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Forbidden */
       403: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description User not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2818,21 +3087,27 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description User not found */
       404: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };
@@ -2862,14 +3137,18 @@ export interface operations {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
       /** @description Internal server error */
       500: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          'application/json': components['schemas']['ErrorMessage'];
+        };
       };
     };
   };


### PR DESCRIPTION
close #405 

---

### Motivation
- Standardize error responses across api_v3 by returning a consistent JSON error object and exposing its schema in OpenAPI and generated types.
- Ensure handler enums and response variants include machine-readable error bodies for non-2xx responses so clients can rely on a stable `message` field.

### Description
- Add `ErrorMessage` (`serde::Serialize`, `utoipa::ToSchema`) with helper constructors and include it in `ApiV3Schemas` so it appears in OpenAPI components. 
- Update many handler response enums to carry `ErrorMessage` for error variants (e.g. `Forbidden`, `NotFound`, `InternalServerError`, `UnprocessableEntity`, `Conflict`, `BadRequest`) and return `Json(ErrorMessage::...)` from handlers where appropriate. 
- Modify `files::get_file_download` to return JSON error bodies for non-OK cases (including redirect error path) using `Response::into_response`. 
- Regenerate OpenAPI JSON (`docs/api/api_v3/openapi.json`) and TypeScript declarations (`libs/shared-types/src/api_v3.d.ts`) to reflect error response bodies referencing the new `ErrorMessage` schema.

### Testing
- Built the Rust workspace with `cargo build --workspace` and ran tests with `cargo test`, which completed successfully. 
- Regenerated API artifacts (OpenAPI and TS types) and validated the generated files via the project type build step using `npm run build` in `libs/shared-types`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a451bbae6b883219430af84a83ea9e3)