### PR TITLE
joinのlocalhostのAPI_URLのurlがv2のままになっていた問題を修正

### DIFF
--- a/apps/join/.env.development
+++ b/apps/join/.env.development
@@ -1,1 +1,1 @@
-API_URL=http://api.koudaisai.localhost/api/v2
+API_URL=http://api.koudaisai.localhost/api/v3


### PR DESCRIPTION
.env.developmentのAPIURLを修正