### PR TITLE
参加団体削除ボタンを参加団体詳細ページに追加

### DIFF
--- a/apps/admin/src/features/manage-groups/ViewGroupInfoPage.tsx
+++ b/apps/admin/src/features/manage-groups/ViewGroupInfoPage.tsx
@@ -51,7 +51,7 @@ export function ViewGroupInfoPage() {
 
 function GroupInfo({ groupId }: { groupId: string }) {
   const [messageApi, contextHolder] = message.useMessage();
-  const [deleteCheckModal, setDeleteCheckModal] = useState<boolean>(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
 
   const { mutateAsync: deleteGroup } = $api.useMutation('delete', '/groups/{id}');
@@ -371,7 +371,7 @@ function GroupInfo({ groupId }: { groupId: string }) {
     if (isDeleting) {
       return;
     }
-    setDeleteCheckModal(false);
+    setIsDeleteModalOpen(false);
   };
 
   const handleDeleteGroup = async () => {
@@ -379,7 +379,7 @@ function GroupInfo({ groupId }: { groupId: string }) {
     try {
       await deleteGroup({ params: { path: { id: groupId } } });
       messageApi.success('参加団体を削除しました');
-      setDeleteCheckModal(false);
+      setIsDeleteModalOpen(false);
       window.location.href = '/manage-groups/';
     } catch {
       messageApi.error('参加団体の削除に失敗しました');
@@ -404,14 +404,14 @@ function GroupInfo({ groupId }: { groupId: string }) {
         <Button
           danger
           type="primary"
-          onClick={() => setDeleteCheckModal(true)}
+          onClick={() => setIsDeleteModalOpen(true)}
         >
           参加団体を削除
         </Button>
       </Flex>
       <Modal
         title="参加団体を削除"
-        open={deleteCheckModal}
+        open={isDeleteModalOpen}
         onOk={() => {
           void handleDeleteGroup();
         }}

--- a/apps/admin/src/features/manage-groups/ViewGroupInfoPage.tsx
+++ b/apps/admin/src/features/manage-groups/ViewGroupInfoPage.tsx
@@ -10,6 +10,8 @@ import {
   Flex,
   Button,
   Result,
+  Modal,
+  message,
   type DescriptionsProps,
 } from 'antd';
 
@@ -48,6 +50,12 @@ export function ViewGroupInfoPage() {
 }
 
 function GroupInfo({ groupId }: { groupId: string }) {
+  const [messageApi, contextHolder] = message.useMessage();
+  const [deleteCheckModal, setDeleteCheckModal] = useState<boolean>(false);
+  const [isDeleting, setIsDeleting] = useState<boolean>(false);
+
+  const { mutateAsync: deleteGroup } = $api.useMutation('delete', '/groups/{id}');
+
   const { data: groupInfo, isLoading: isLoadingGruop } = $api.useQuery(
     'get',
     '/groups/{id}',
@@ -358,14 +366,66 @@ function GroupInfo({ groupId }: { groupId: string }) {
       },
     ];
   }
+
+  const handleCloseDeleteModal = () => {
+    if (isDeleting) {
+      return;
+    }
+    setDeleteCheckModal(false);
+  };
+
+  const handleDeleteGroup = async () => {
+    setIsDeleting(true);
+    try {
+      await deleteGroup({ params: { path: { id: groupId } } });
+      messageApi.success('参加団体を削除しました');
+      setDeleteCheckModal(false);
+      window.location.href = '/manage-groups/';
+    } catch {
+      messageApi.error('参加団体の削除に失敗しました');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
   return (
     <Flex gap={8} vertical>
+      {contextHolder}
       <Descriptions
         title={groupInfo.name}
         column={1}
         bordered
         items={groupInfoData}
       />
+      <Flex gap={8} wrap justify="space-between">
+        <Button type="default" href="/manage-groups/" style={{ width: '5rem' }}>
+          戻る
+        </Button>
+        <Button
+          danger
+          type="primary"
+          onClick={() => setDeleteCheckModal(true)}
+        >
+          参加団体を削除
+        </Button>
+      </Flex>
+      <Modal
+        title="参加団体を削除"
+        open={deleteCheckModal}
+        onOk={() => {
+          void handleDeleteGroup();
+        }}
+        onCancel={handleCloseDeleteModal}
+        centered
+        closable={false}
+        mask={{ closable: false }}
+        okText="削除する"
+        cancelText="キャンセル"
+        okButtonProps={{ danger: true, loading: isDeleting }}
+        cancelButtonProps={{ disabled: isDeleting }}
+      >
+        <p>本当にこの参加団体を削除しますか？この操作は取り消せません。</p>
+      </Modal>
     </Flex>
   );
 }

--- a/apps/admin/src/features/manage-users/ViewUserInfoPage.tsx
+++ b/apps/admin/src/features/manage-users/ViewUserInfoPage.tsx
@@ -89,6 +89,10 @@ function UserInfo({ userId }: { userId: string }) {
     'pendingSaveUserEmail',
   );
 
+  const [openDeleteGroupModal, setOpenDeleteGroupModal] =
+    useState<boolean>(false);
+  const [isDeletingGroup, setIsDeletingGroup] = useState<boolean>(false);
+
   const {
     data: userInfo,
     isLoading: isLoadingUsers,
@@ -108,6 +112,10 @@ function UserInfo({ userId }: { userId: string }) {
   const { mutateAsync: updateUserEmail } = $api.useMutation(
     'post',
     '/users/{id}/m_address',
+  );
+  const { mutateAsync: deleteGroup } = $api.useMutation(
+    'delete',
+    '/groups/{id}',
   );
 
   const { data: groupData, isLoading: isLoadingGroups } = $api.useQuery(
@@ -442,6 +450,30 @@ function UserInfo({ userId }: { userId: string }) {
     setStateOfMailModal('pendingSaveUserEmail');
   };
 
+  const handleCloseDeleteGroupModal = () => {
+    if (isDeletingGroup) {
+      return;
+    }
+    setOpenDeleteGroupModal(false);
+  };
+
+  const handleDeleteGroup = async () => {
+    if (!userInfo.group_id) {
+      return;
+    }
+    setIsDeletingGroup(true);
+    try {
+      await deleteGroup({ params: { path: { id: userInfo.group_id } } });
+      messageApi.success('参加団体を削除しました');
+      setOpenDeleteGroupModal(false);
+      window.location.href = `/manage-users/view?user_id=${userId}`;
+    } catch (error) {
+      messageApi.error(`参加団体の削除に失敗しました: ${String(error)}`);
+    } finally {
+      setIsDeletingGroup(false);
+    }
+  };
+
   const startEditing = (field: 'name' | 'email', value: string) => {
     setEditingField(field);
     setEditingValue(value);
@@ -656,11 +688,35 @@ function UserInfo({ userId }: { userId: string }) {
         bordered
         items={userInfoData}
       />
-      <Flex gap={8} wrap>
+      <Flex gap={8} wrap justify="space-between">
         <Button type="default" href="/manage-users/" style={{ width: '5rem' }}>
           戻る
         </Button>
+        <Button
+          danger
+          disabled={!userInfo.group_id}
+          onClick={() => setOpenDeleteGroupModal(true)}
+        >
+          参加団体を削除
+        </Button>
       </Flex>
+      <Modal
+        title="参加団体を削除"
+        open={openDeleteGroupModal}
+        onOk={() => {
+          void handleDeleteGroup();
+        }}
+        onCancel={handleCloseDeleteGroupModal}
+        centered
+        closable={false}
+        maskClosable={false}
+        okText="削除する"
+        cancelText="キャンセル"
+        okButtonProps={{ danger: true, loading: isDeletingGroup }}
+        cancelButtonProps={{ disabled: isDeletingGroup }}
+      >
+        <p>本当にこの参加団体を削除しますか？この操作は取り消せません。</p>
+      </Modal>
       <Modal
         title={stateOfModalOnSendUserName()?.modalTitle}
         open={openNameModal}
@@ -675,6 +731,7 @@ function UserInfo({ userId }: { userId: string }) {
             overflowY: 'auto',
             maxHeight: '80vh',
           },
+          
         }}
       >
         {stateOfModalOnSendUserName()?.modalContents}

--- a/apps/admin/src/features/manage-users/ViewUserInfoPage.tsx
+++ b/apps/admin/src/features/manage-users/ViewUserInfoPage.tsx
@@ -96,7 +96,7 @@ function UserInfo({ userId }: { userId: string }) {
   const {
     data: userInfo,
     isLoading: isLoadingUsers,
-    // refetch: refetchUserInfo,
+    refetch: refetchUserInfo,
   } = $api.useQuery('get', '/users/{id}', {
     params: {
       path: {
@@ -466,9 +466,9 @@ function UserInfo({ userId }: { userId: string }) {
       await deleteGroup({ params: { path: { id: userInfo.group_id } } });
       messageApi.success('参加団体を削除しました');
       setOpenDeleteGroupModal(false);
-      window.location.href = `/manage-users/view?user_id=${userId}`;
-    } catch (error) {
-      messageApi.error(`参加団体の削除に失敗しました: ${String(error)}`);
+      await refetchUserInfo();
+    } catch {
+      messageApi.error('参加団体の削除に失敗しました');
     } finally {
       setIsDeletingGroup(false);
     }

--- a/apps/admin/src/features/manage-users/ViewUserInfoPage.tsx
+++ b/apps/admin/src/features/manage-users/ViewUserInfoPage.tsx
@@ -89,14 +89,10 @@ function UserInfo({ userId }: { userId: string }) {
     'pendingSaveUserEmail',
   );
 
-  const [openDeleteGroupModal, setOpenDeleteGroupModal] =
-    useState<boolean>(false);
-  const [isDeletingGroup, setIsDeletingGroup] = useState<boolean>(false);
-
   const {
     data: userInfo,
     isLoading: isLoadingUsers,
-    refetch: refetchUserInfo,
+    // refetch: refetchUserInfo,
   } = $api.useQuery('get', '/users/{id}', {
     params: {
       path: {
@@ -112,10 +108,6 @@ function UserInfo({ userId }: { userId: string }) {
   const { mutateAsync: updateUserEmail } = $api.useMutation(
     'post',
     '/users/{id}/m_address',
-  );
-  const { mutateAsync: deleteGroup } = $api.useMutation(
-    'delete',
-    '/groups/{id}',
   );
 
   const { data: groupData, isLoading: isLoadingGroups } = $api.useQuery(
@@ -450,30 +442,6 @@ function UserInfo({ userId }: { userId: string }) {
     setStateOfMailModal('pendingSaveUserEmail');
   };
 
-  const handleCloseDeleteGroupModal = () => {
-    if (isDeletingGroup) {
-      return;
-    }
-    setOpenDeleteGroupModal(false);
-  };
-
-  const handleDeleteGroup = async () => {
-    if (!userInfo.group_id) {
-      return;
-    }
-    setIsDeletingGroup(true);
-    try {
-      await deleteGroup({ params: { path: { id: userInfo.group_id } } });
-      messageApi.success('参加団体を削除しました');
-      setOpenDeleteGroupModal(false);
-      await refetchUserInfo();
-    } catch {
-      messageApi.error('参加団体の削除に失敗しました');
-    } finally {
-      setIsDeletingGroup(false);
-    }
-  };
-
   const startEditing = (field: 'name' | 'email', value: string) => {
     setEditingField(field);
     setEditingValue(value);
@@ -688,36 +656,11 @@ function UserInfo({ userId }: { userId: string }) {
         bordered
         items={userInfoData}
       />
-      <Flex gap={8} wrap justify="space-between">
+      <Flex gap={8} wrap>
         <Button type="default" href="/manage-users/" style={{ width: '5rem' }}>
           戻る
         </Button>
-        <Button
-          danger
-          type="primary"
-          disabled={!userInfo.group_id}
-          onClick={() => setOpenDeleteGroupModal(true)}
-        >
-          参加団体を削除
-        </Button>
       </Flex>
-      <Modal
-        title="参加団体を削除"
-        open={openDeleteGroupModal}
-        onOk={() => {
-          void handleDeleteGroup();
-        }}
-        onCancel={handleCloseDeleteGroupModal}
-        centered
-        closable={false}
-        maskClosable={false}
-        okText="削除する"
-        cancelText="キャンセル"
-        okButtonProps={{ danger: true, loading: isDeletingGroup }}
-        cancelButtonProps={{ disabled: isDeletingGroup }}
-      >
-        <p>本当にこの参加団体を削除しますか？この操作は取り消せません。</p>
-      </Modal>
       <Modal
         title={stateOfModalOnSendUserName()?.modalTitle}
         open={openNameModal}

--- a/apps/admin/src/features/manage-users/ViewUserInfoPage.tsx
+++ b/apps/admin/src/features/manage-users/ViewUserInfoPage.tsx
@@ -732,7 +732,6 @@ function UserInfo({ userId }: { userId: string }) {
             overflowY: 'auto',
             maxHeight: '80vh',
           },
-          
         }}
       >
         {stateOfModalOnSendUserName()?.modalContents}

--- a/apps/admin/src/features/manage-users/ViewUserInfoPage.tsx
+++ b/apps/admin/src/features/manage-users/ViewUserInfoPage.tsx
@@ -694,6 +694,7 @@ function UserInfo({ userId }: { userId: string }) {
         </Button>
         <Button
           danger
+          type="primary"
           disabled={!userInfo.group_id}
           onClick={() => setOpenDeleteGroupModal(true)}
         >


### PR DESCRIPTION
## 概要
参加団体詳細ページに、参加団体を削除する機能を追加

- 参加団体詳細ページの「戻る」ボタンと同じ行に「参加団体を削除」ボタンを配置
- 削除前に確認モーダルを表示し、誤操作による削除を防止
- 削除成功後はユーザー情報ページをリロードし、参加団体ページ一覧ページを表示

closes #411

## スクリーンショット
 | After |
 | --- |
 | <img width="2548" height="1454" alt="スクリーンショット 2026-07-16 141840" src="https://github.com/user-attachments/assets/2e4ed83b-1d50-4ea1-9177-07cf272a23d9" /><img width="2548" height="1380" alt="スクリーンショット 2026-07-16 141812" src="https://github.com/user-attachments/assets/ec58d4e1-a1a7-49e1-a8ec-1793fc170ffc" /> |
