### PR TITLE
ユーザー管理画面からユーザー削除

### DIFF
--- a/apps/admin/src/features/manage-users/ViewUserInfoPage.tsx
+++ b/apps/admin/src/features/manage-users/ViewUserInfoPage.tsx
@@ -79,7 +79,7 @@ function UserInfo({ userId }: { userId: string }) {
   const [isPendSaving, setIsPendSaving] = useState<boolean>(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isCopying, setIsCopying] = useState<boolean>(false);
-  const [deleteCheckModal, setDeleteCheckModal] = useState<boolean>(false);
+  const [openDeleteModal, setOpenDeleteModal] = useState<boolean>(false);
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
 
   const [openNameModal, setOpenNameModal] = useState<boolean>(false);
@@ -551,7 +551,7 @@ function UserInfo({ userId }: { userId: string }) {
     if (isDeleting) {
       return;
     }
-    setDeleteCheckModal(false);
+    setOpenDeleteModal(false);
   };
 
   const handleDeleteUser = async () => {
@@ -559,7 +559,7 @@ function UserInfo({ userId }: { userId: string }) {
     try {
       await deleteUser({ params: { path: { id: userId } } });
       messageApi.success('ユーザーを削除しました');
-      setDeleteCheckModal(false);
+      setOpenDeleteModal(false);
       window.location.href = '/manage-users/';
     } catch {
       messageApi.error('ユーザーの削除に失敗しました');
@@ -688,14 +688,14 @@ function UserInfo({ userId }: { userId: string }) {
         <Button
           danger
           type="primary"
-          onClick={() => setDeleteCheckModal(true)}
+          onClick={() => setOpenDeleteModal(true)}
         >
           削除
         </Button>
       </Flex>
       <Modal
         title="ユーザーを削除"
-        open={deleteCheckModal}
+        open={openDeleteModal}
         onOk={() => {
           void handleDeleteUser();
         }}

--- a/apps/admin/src/features/manage-users/ViewUserInfoPage.tsx
+++ b/apps/admin/src/features/manage-users/ViewUserInfoPage.tsx
@@ -79,6 +79,8 @@ function UserInfo({ userId }: { userId: string }) {
   const [isPendSaving, setIsPendSaving] = useState<boolean>(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isCopying, setIsCopying] = useState<boolean>(false);
+  const [deleteCheckModal, setDeleteCheckModal] = useState<boolean>(false);
+  const [isDeleting, setIsDeleting] = useState<boolean>(false);
 
   const [openNameModal, setOpenNameModal] = useState<boolean>(false);
   const [openEmailModal, setOpenEmailModal] = useState<boolean>(false);
@@ -88,6 +90,8 @@ function UserInfo({ userId }: { userId: string }) {
   const [stateOfMailModal, setStateOfMailModal] = useState<StateOfModal>(
     'pendingSaveUserEmail',
   );
+
+  const { mutateAsync: deleteUser } = $api.useMutation('delete', '/users/{id}');
 
   const {
     data: userInfo,
@@ -543,6 +547,27 @@ function UserInfo({ userId }: { userId: string }) {
     }
   };
 
+  const handleCloseDeleteModal = () => {
+    if (isDeleting) {
+      return;
+    }
+    setDeleteCheckModal(false);
+  };
+
+  const handleDeleteUser = async () => {
+    setIsDeleting(true);
+    try {
+      await deleteUser({ params: { path: { id: userId } } });
+      messageApi.success('ユーザーを削除しました');
+      setDeleteCheckModal(false);
+      window.location.href = '/manage-users/';
+    } catch {
+      messageApi.error('ユーザーの削除に失敗しました');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
   const handleCopyActivationUrl = async () => {
     try {
       setIsCopying(true);
@@ -656,11 +681,35 @@ function UserInfo({ userId }: { userId: string }) {
         bordered
         items={userInfoData}
       />
-      <Flex gap={8} wrap>
+      <Flex gap={8} wrap justify="space-between">
         <Button type="default" href="/manage-users/" style={{ width: '5rem' }}>
           戻る
         </Button>
+        <Button
+          danger
+          type="primary"
+          onClick={() => setDeleteCheckModal(true)}
+        >
+          削除
+        </Button>
       </Flex>
+      <Modal
+        title="ユーザーを削除"
+        open={deleteCheckModal}
+        onOk={() => {
+          void handleDeleteUser();
+        }}
+        onCancel={handleCloseDeleteModal}
+        centered
+        closable={false}
+        mask={{ closable: false }}
+        okText="削除する"
+        cancelText="キャンセル"
+        okButtonProps={{ danger: true, loading: isDeleting }}
+        cancelButtonProps={{ disabled: isDeleting }}
+      >
+        <p>本当にこのユーザーを削除しますか？この操作は取り消せません。</p>
+      </Modal>
       <Modal
         title={stateOfModalOnSendUserName()?.modalTitle}
         open={openNameModal}


### PR DESCRIPTION
## 概要

- ユーザー詳細画面(`ViewUserInfoPage`)に「ユーザーを削除」ボタンを追加
- 誤操作防止のため、削除ボタン押下時に確認用モーダルを表示し、モーダル内での操作でのみ削除が完了
- 削除成功後は一覧画面(`/manage-users/`)へ遷移

## 関連Issue

close #354

## スクリーンショット
| after |
| -- |
|<img width="2542" height="1420" alt="スクリーンショット 2026-07-16 173213" src="https://github.com/user-attachments/assets/d3bd8a9c-970f-4a09-963b-9c7154b0d4c1" /><img width="2572" height="1460" alt="スクリーンショット 2026-07-16 173206" src="https://github.com/user-attachments/assets/8672d6ea-0cb4-425c-8222-1ca845c5cd71" />|
