### PR TITLE
WIP: 参加団体詳細ページから責任者の変更機能の追加

### DIFF
--- a/apps/admin/src/features/manage-groups/EditableMemberField.tsx
+++ b/apps/admin/src/features/manage-groups/EditableMemberField.tsx
@@ -1,0 +1,167 @@
+import { $api, api } from '@/features/api/api';
+import { type Role } from '@koudaisai/shared-types';
+import { useState, type ReactNode } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Flex, Button, Select } from 'antd';
+import type { MessageInstance } from 'antd/es/message/interface';
+
+const roleLabels: Record<Role, string> = {
+  representative: '企画責任者',
+  operator: '企画実施担当者',
+  first_responsible: '第1責任者',
+  second_responsible: '第2責任者',
+  third_responsible: '第3責任者',
+};
+
+export function EditableMemberField({
+  groupId,
+  role,
+  displayNode,
+  currentUserId,
+  messageApi,
+  onSaved,
+}: {
+  groupId: string;
+  role: Role;
+  displayNode: ReactNode;
+  currentUserId: string;
+  messageApi: MessageInstance;
+  onSaved: () => Promise<unknown>;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [selectedUserId, setSelectedUserId] = useState<string>('');
+  const [isSavingMember, setIsSavingMember] = useState(false);
+
+  const { data: allUsers, isLoading: isLoadingAllUsers } = $api.useQuery(
+    'get',
+    '/users',
+    {},
+    { enabled: isEditing },
+  );
+  const { data: allGroups, isLoading: isLoadingAllGroups } = $api.useQuery(
+    'get',
+    '/groups',
+    {},
+    { enabled: isEditing },
+  );
+  const { data: assignedUserIds, isLoading: isLoadingAssignedUserIds } =
+    useQuery({
+      queryKey: ['all-group-members', allGroups?.map((g) => g.id)],
+      queryFn: async () => {
+        const results = await Promise.all(
+          (allGroups ?? []).map((g) =>
+            api.GET('/groups/{id}/members', {
+              params: { path: { id: g.id } },
+            }),
+          ),
+        );
+        const ids = new Set<string>();
+        for (const result of results) {
+          for (const member of result.data ?? []) {
+            ids.add(member.user_id);
+          }
+        }
+        return ids;
+      },
+      enabled: isEditing && Boolean(allGroups),
+    });
+
+  const { mutateAsync: putMember } = $api.useMutation(
+    'put',
+    '/groups/{id}/members/{role}',
+  );
+  const { mutateAsync: deleteMember } = $api.useMutation(
+    'delete',
+    '/groups/{id}/members/{role}',
+  );
+
+  const roleLabel = roleLabels[role];
+
+  const startEditing = () => {
+    setIsEditing(true);
+    setSelectedUserId(currentUserId);
+  };
+
+  const cancelEditing = () => {
+    setIsEditing(false);
+    setSelectedUserId('');
+  };
+
+  const handleSaveMember = async () => {
+    setIsSavingMember(true);
+    try {
+      if (selectedUserId) {
+        await putMember({
+          params: { path: { id: groupId, role } },
+          body: { user_id: selectedUserId },
+        });
+      } else {
+        await deleteMember({
+          params: { path: { id: groupId, role } },
+        });
+      }
+      await onSaved();
+      messageApi.success(`${roleLabel}を更新しました`);
+      setIsSavingMember(false);
+      cancelEditing();
+    } catch (error) {
+      messageApi.error(`${roleLabel}の更新に失敗しました: ${String(error)}`);
+      setIsSavingMember(false);
+    }
+  };
+
+  if (!isEditing) {
+    return (
+      <Flex gap={8} align="center" justify="space-between">
+        <span>{displayNode}</span>
+        <Button size="small" onClick={startEditing}>
+          編集
+        </Button>
+      </Flex>
+    );
+  }
+
+  const isLoadingOptions =
+    isLoadingAllUsers || isLoadingAllGroups || isLoadingAssignedUserIds;
+  const options = (allUsers ?? [])
+    .filter(
+      (user) => !assignedUserIds?.has(user.id) || user.id === currentUserId,
+    )
+    .map((user) => ({
+      value: user.id,
+      label: `${user.name}(${user.m_address})`,
+    }));
+
+  return (
+    <Flex gap={8} align="start" wrap>
+      <Select
+        showSearch={{
+          filterOption: (input, option) =>
+            (option?.label ?? '').toLowerCase().includes(input.toLowerCase()),
+        }}
+        allowClear
+        placeholder="ユーザーを選択"
+        style={{ width: 'min(100%, 28rem)' }}
+        value={selectedUserId || undefined}
+        onChange={(value) => setSelectedUserId(value ?? '')}
+        options={options}
+        loading={isLoadingOptions}
+        disabled={isLoadingOptions || isSavingMember}
+        autoFocus
+      />
+      <Button
+        type="primary"
+        onClick={() => {
+          void handleSaveMember();
+        }}
+        disabled={isLoadingOptions}
+        loading={isSavingMember}
+      >
+        保存
+      </Button>
+      <Button onClick={cancelEditing} disabled={isSavingMember}>
+        キャンセル
+      </Button>
+    </Flex>
+  );
+}

--- a/apps/admin/src/features/manage-groups/EditableMemberField.tsx
+++ b/apps/admin/src/features/manage-groups/EditableMemberField.tsx
@@ -156,7 +156,7 @@ export function EditableMemberField({
         onClick={() => {
           void handleSaveMember();
         }}
-        disabled={isLoadingOptions}
+        disabled={isLoadingOptions || isSavingMember}
         loading={isSavingMember}
       >
         保存

--- a/apps/admin/src/features/manage-groups/EditableMemberField.tsx
+++ b/apps/admin/src/features/manage-groups/EditableMemberField.tsx
@@ -57,12 +57,14 @@ export function EditableMemberField({
         );
         const ids = new Set<string>();
         for (const result of results) {
+          if (result.error) {
+            throw result.error;
+          }
           for (const member of result.data ?? []) {
             ids.add(member.user_id);
           }
         }
         return ids;
-      },
       enabled: isEditing && Boolean(allGroups),
     });
 

--- a/apps/admin/src/features/manage-groups/EditableMemberField.tsx
+++ b/apps/admin/src/features/manage-groups/EditableMemberField.tsx
@@ -65,6 +65,7 @@ export function EditableMemberField({
           }
         }
         return ids;
+      },
       enabled: isEditing && Boolean(allGroups),
     });
 

--- a/apps/admin/src/features/manage-groups/ViewGroupInfoPage.tsx
+++ b/apps/admin/src/features/manage-groups/ViewGroupInfoPage.tsx
@@ -10,8 +10,10 @@ import {
   Flex,
   Button,
   Result,
+  message,
   type DescriptionsProps,
 } from 'antd';
+import { EditableMemberField } from './EditableMemberField';
 
 export function ViewGroupInfoPage() {
   const [queryClient] = useState(() => new QueryClient());
@@ -48,6 +50,8 @@ export function ViewGroupInfoPage() {
 }
 
 function GroupInfo({ groupId }: { groupId: string }) {
+  const [messageApi, contextHolder] = message.useMessage();
+
   const { data: groupInfo, isLoading: isLoadingGruop } = $api.useQuery(
     'get',
     '/groups/{id}',
@@ -59,17 +63,17 @@ function GroupInfo({ groupId }: { groupId: string }) {
       },
     },
   );
-  const { data: memberInfo, isLoading: isLoadingMember } = $api.useQuery(
-    'get',
-    '/groups/{id}/members',
-    {
-      params: {
-        path: {
-          id: groupId,
-        },
+  const {
+    data: memberInfo,
+    isLoading: isLoadingMember,
+    refetch: refetchMemberInfo,
+  } = $api.useQuery('get', '/groups/{id}/members', {
+    params: {
+      path: {
+        id: groupId,
       },
     },
-  );
+  });
 
   const filteredMemberByRole = {
     representative:
@@ -301,12 +305,30 @@ function GroupInfo({ groupId }: { groupId: string }) {
       {
         key: 'representative',
         label: '企画責任者',
-        children: filteredMemberNameByRole.representative,
+        children: (
+          <EditableMemberField
+            groupId={groupId}
+            role="representative"
+            displayNode={filteredMemberNameByRole.representative}
+            currentUserId={filteredMemberByRole.representative}
+            messageApi={messageApi}
+            onSaved={refetchMemberInfo}
+          />
+        ),
       },
       {
         key: 'operator',
         label: '企画実施担当者',
-        children: filteredMemberNameByRole.operator,
+        children: (
+          <EditableMemberField
+            groupId={groupId}
+            role="operator"
+            displayNode={filteredMemberNameByRole.operator}
+            currentUserId={filteredMemberByRole.operator}
+            messageApi={messageApi}
+            onSaved={refetchMemberInfo}
+          />
+        ),
       },
       {
         key: 'created_at',
@@ -334,17 +356,44 @@ function GroupInfo({ groupId }: { groupId: string }) {
       {
         key: 'first_responsible',
         label: '第1責任者',
-        children: filteredMemberNameByRole.first_responsible,
+        children: (
+          <EditableMemberField
+            groupId={groupId}
+            role="first_responsible"
+            displayNode={filteredMemberNameByRole.first_responsible}
+            currentUserId={filteredMemberByRole.first_responsible}
+            messageApi={messageApi}
+            onSaved={refetchMemberInfo}
+          />
+        ),
       },
       {
         key: 'second_responsible',
         label: '第2責任者',
-        children: filteredMemberNameByRole.second_responsible,
+        children: (
+          <EditableMemberField
+            groupId={groupId}
+            role="second_responsible"
+            displayNode={filteredMemberNameByRole.second_responsible}
+            currentUserId={filteredMemberByRole.second_responsible}
+            messageApi={messageApi}
+            onSaved={refetchMemberInfo}
+          />
+        ),
       },
       {
         key: 'third_responsible',
         label: '第3責任者',
-        children: filteredMemberNameByRole.third_responsible,
+        children: (
+          <EditableMemberField
+            groupId={groupId}
+            role="third_responsible"
+            displayNode={filteredMemberNameByRole.third_responsible}
+            currentUserId={filteredMemberByRole.third_responsible}
+            messageApi={messageApi}
+            onSaved={refetchMemberInfo}
+          />
+        ),
       },
       {
         key: 'created_at',
@@ -366,6 +415,7 @@ function GroupInfo({ groupId }: { groupId: string }) {
         bordered
         items={groupInfoData}
       />
+      {contextHolder}
     </Flex>
   );
 }


### PR DESCRIPTION
## 概要
管理画面の団体詳細ページ(`ViewGroupInfoPage`)で、企画責任者・企画実施担当者・第1〜第3責任者を、別ページに遷移せずその場で編集・保存できるようにする

## 詳細変更
- 新規コンポーネント `EditableMemberField` を追加。「表示 → 編集(ユーザー検索付きセレクト) → 保存/キャンセル」を切り替えるUIで、責任者・担当者の5つの役職欄すべてに適用
- 選択肢のユーザーは、既に他の団体の役職に割り当て済みのユーザーを自動的に除外(全団体のメンバー一覧を突き合わせて判定)。ただし現在その役職に割り当てられている本人は選択肢に残るようにしている
- 保存はユーザーを選択していれば `PUT /groups/{id}/members/{role}`、未選択(クリア)であれば `DELETE /groups/{id}/members/{role}` を呼び、責任者を空欄にする操作にも対応
- 保存結果は確認モーダルなどを挟まず、トースト通知(成功/失敗)のみでフィードバック。保存中は各操作ボタンをローディング/disabled状態にして二重送信や誤操作を防止
- `ViewGroupInfoPage` 側では `useQuery` から `refetch` を取り出し、保存完了後に責任者一覧を再取得して画面に即時反映されるようにした

## 関連issue
close #414

## スクリーンショット
<!-- ここに動作確認時のスクリーンショットを貼ってください -->
| after |
| --|
|<img width="2064" height="996" alt="スクリーンショット 2026-07-17 145558" src="https://github.com/user-attachments/assets/8ca6c684-a39c-4cbf-8ef9-402b2ecd6972" />
<img width="2094" height="530" alt="スクリーンショット 2026-07-17 145533" src="https://github.com/user-attachments/assets/15e14b86-1058-4398-8205-92c0787f1274" />
<img width="2034" height="1044" alt="スクリーンショット 2026-07-17 151150" src="https://github.com/user-attachments/assets/bbbc36b1-13b0-4189-880a-b60415a29da0" />|