### PR TITLE
fix(backend): 数値 enum のプロパティを正しい型で中継・公開する

### DIFF
--- a/apps/admin/src/features/events26/Events26Page.tsx
+++ b/apps/admin/src/features/events26/Events26Page.tsx
@@ -4,10 +4,7 @@ import {
   FolderOpenOutlined,
   UploadOutlined,
 } from '@ant-design/icons';
-import type {
-  apiComponents,
-  events26Components,
-} from '@koudaisai/shared-types';
+import type { events26Components } from '@koudaisai/shared-types';
 import { Heading1, LoadingScreen } from '@koudaisai/shared-ui';
 import { useDownload } from '@koudaisai/shared-utils';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -35,16 +32,6 @@ type Place = NonNullable<Occasion['place']>;
 type Time = events26Components['schemas']['Time'];
 type FoodStallTag = events26Components['schemas']['FoodStallTag'];
 type GeneralTag = events26Components['schemas']['GeneralTag'];
-
-/**
- * backend 中継(`/api/v3/events26`)が公開している `Project` スキーマ。
- *
- * 中身は events26 の `Project` と同じものだが、backend 側の生成クライアントで
- * `Time.date` が events26 の `1 | 2` ではなく `string` として公開されており、
- * 型としては一致しない。正本は events26 の spec なのでこちらで組み立て、
- * 送信時だけこの型へ寄せる。backend 側のスキーマが直ったらキャストは外せる。
- */
-type ApiProject = apiComponents['schemas']['Project'];
 
 /** CSV の 1 行。すべての列を文字列として読み書きする。 */
 type ProjectRow = {
@@ -495,14 +482,14 @@ function Events26Table() {
 
   const handleBulkCreate = (csv: string) =>
     applyCsv(csv, '新規作成', (project) =>
-      mutateProjectCreate({ body: project as unknown as ApiProject }),
+      mutateProjectCreate({ body: project }),
     );
 
   const handleBulkReplace = (csv: string) =>
     applyCsv(csv, '更新', (project) =>
       mutateProjectReplace({
         params: { path: { project_id: project.id } },
-        body: project as unknown as ApiProject,
+        body: project,
       }),
     );
 

--- a/apps/backend/generated/events26_api/Cargo.toml
+++ b/apps/backend/generated/events26_api/Cargo.toml
@@ -11,7 +11,9 @@ edition = "2021"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
-utoipa = "^5.5"
+# repr: 数値 enum のプロパティ(serde_repr + #[repr(i64)])を、変種名ではなく
+# 実際の数値としてスキーマに出すために要る。
+utoipa = { version = "^5.5", features = ["repr"] }
 url = "^2.5"
 tokio = { version = "^1.46.0", features = ["fs"] }
 tokio-util = { version = "^0.7", features = ["codec"] }

--- a/apps/backend/generated/events26_api/src/models/building.rs
+++ b/apps/backend/generated/events26_api/src/models/building.rs
@@ -18,7 +18,7 @@ pub struct Building {
     #[serde(rename = "displayName")]
     pub display_name: String,
     #[serde(rename = "type")]
-    pub r#type: Type,
+    pub r#type: BuildingType,
     #[serde(rename = "rooms")]
     pub rooms: Vec<models::Room>,
 }
@@ -27,7 +27,7 @@ impl Building {
     pub fn new(
         name: String,
         display_name: String,
-        r#type: Type,
+        r#type: BuildingType,
         rooms: Vec<models::Room>,
     ) -> Building {
         Building {
@@ -52,14 +52,13 @@ impl Building {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = BuildingType)]
-pub enum Type {
+pub enum BuildingType {
     #[serde(rename = "building")]
     Building,
 }
 
-impl Default for Type {
-    fn default() -> Type {
+impl Default for BuildingType {
+    fn default() -> BuildingType {
         Self::Building
     }
 }

--- a/apps/backend/generated/events26_api/src/models/district.rs
+++ b/apps/backend/generated/events26_api/src/models/district.rs
@@ -18,7 +18,7 @@ pub struct District {
     #[serde(rename = "displayName")]
     pub display_name: String,
     #[serde(rename = "type")]
-    pub r#type: Type,
+    pub r#type: DistrictType,
     #[serde(rename = "venues")]
     pub venues: Vec<models::Venue>,
 }
@@ -27,7 +27,7 @@ impl District {
     pub fn new(
         name: String,
         display_name: String,
-        r#type: Type,
+        r#type: DistrictType,
         venues: Vec<models::Venue>,
     ) -> District {
         District {
@@ -52,14 +52,13 @@ impl District {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = DistrictType)]
-pub enum Type {
+pub enum DistrictType {
     #[serde(rename = "district")]
     District,
 }
 
-impl Default for Type {
-    fn default() -> Type {
+impl Default for DistrictType {
+    fn default() -> DistrictType {
         Self::District
     }
 }

--- a/apps/backend/generated/events26_api/src/models/drink_food_stall_tag.rs
+++ b/apps/backend/generated/events26_api/src/models/drink_food_stall_tag.rs
@@ -14,11 +14,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct DrinkFoodStallTag {
     #[serde(rename = "tag")]
-    pub tag: Tag,
+    pub tag: DrinkFoodStallTagTag,
 }
 
 impl DrinkFoodStallTag {
-    pub fn new(tag: Tag) -> DrinkFoodStallTag {
+    pub fn new(tag: DrinkFoodStallTagTag) -> DrinkFoodStallTag {
         DrinkFoodStallTag { tag }
     }
 }
@@ -36,14 +36,13 @@ impl DrinkFoodStallTag {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = DrinkFoodStallTagTag)]
-pub enum Tag {
+pub enum DrinkFoodStallTagTag {
     #[serde(rename = "drink")]
     Drink,
 }
 
-impl Default for Tag {
-    fn default() -> Tag {
+impl Default for DrinkFoodStallTagTag {
+    fn default() -> DrinkFoodStallTagTag {
         Self::Drink
     }
 }

--- a/apps/backend/generated/events26_api/src/models/food_stall_area.rs
+++ b/apps/backend/generated/events26_api/src/models/food_stall_area.rs
@@ -18,7 +18,7 @@ pub struct FoodStallArea {
     #[serde(rename = "displayName")]
     pub display_name: String,
     #[serde(rename = "type")]
-    pub r#type: Type,
+    pub r#type: FoodStallAreaType,
     #[serde(rename = "slots")]
     pub slots: Vec<models::FoodStallSlot>,
 }
@@ -27,7 +27,7 @@ impl FoodStallArea {
     pub fn new(
         name: String,
         display_name: String,
-        r#type: Type,
+        r#type: FoodStallAreaType,
         slots: Vec<models::FoodStallSlot>,
     ) -> FoodStallArea {
         FoodStallArea {
@@ -52,14 +52,13 @@ impl FoodStallArea {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = FoodStallAreaType)]
-pub enum Type {
+pub enum FoodStallAreaType {
     #[serde(rename = "food_stall_area")]
     FoodStallArea,
 }
 
-impl Default for Type {
-    fn default() -> Type {
+impl Default for FoodStallAreaType {
+    fn default() -> FoodStallAreaType {
         Self::FoodStallArea
     }
 }

--- a/apps/backend/generated/events26_api/src/models/food_stall_project.rs
+++ b/apps/backend/generated/events26_api/src/models/food_stall_project.rs
@@ -28,7 +28,7 @@ pub struct FoodStallProject {
     #[serde(rename = "occasions")]
     pub occasions: Vec<models::Occasion>,
     #[serde(rename = "type")]
-    pub r#type: Type,
+    pub r#type: FoodStallProjectType,
     #[serde(rename = "tag")]
     pub tag: Vec<models::FoodStallTag>,
 }
@@ -42,7 +42,7 @@ impl FoodStallProject {
         is_child_friendly: bool,
         is_recommended: bool,
         occasions: Vec<models::Occasion>,
-        r#type: Type,
+        r#type: FoodStallProjectType,
         tag: Vec<models::FoodStallTag>,
     ) -> FoodStallProject {
         FoodStallProject {
@@ -72,14 +72,13 @@ impl FoodStallProject {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = FoodStallProjectType)]
-pub enum Type {
+pub enum FoodStallProjectType {
     #[serde(rename = "food-stall")]
     FoodStall,
 }
 
-impl Default for Type {
-    fn default() -> Type {
+impl Default for FoodStallProjectType {
+    fn default() -> FoodStallProjectType {
         Self::FoodStall
     }
 }

--- a/apps/backend/generated/events26_api/src/models/food_stall_slot.rs
+++ b/apps/backend/generated/events26_api/src/models/food_stall_slot.rs
@@ -18,11 +18,11 @@ pub struct FoodStallSlot {
     #[serde(rename = "displayName")]
     pub display_name: String,
     #[serde(rename = "type")]
-    pub r#type: Type,
+    pub r#type: FoodStallSlotType,
 }
 
 impl FoodStallSlot {
-    pub fn new(name: String, display_name: String, r#type: Type) -> FoodStallSlot {
+    pub fn new(name: String, display_name: String, r#type: FoodStallSlotType) -> FoodStallSlot {
         FoodStallSlot {
             name,
             display_name,
@@ -44,14 +44,13 @@ impl FoodStallSlot {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = FoodStallSlotType)]
-pub enum Type {
+pub enum FoodStallSlotType {
     #[serde(rename = "food_stall_slot")]
     FoodStallSlot,
 }
 
-impl Default for Type {
-    fn default() -> Type {
+impl Default for FoodStallSlotType {
+    fn default() -> FoodStallSlotType {
         Self::FoodStallSlot
     }
 }

--- a/apps/backend/generated/events26_api/src/models/food_stall_tag.rs
+++ b/apps/backend/generated/events26_api/src/models/food_stall_tag.rs
@@ -38,14 +38,13 @@ impl Default for FoodStallTag {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = FoodStallTagTag)]
-pub enum Tag {
+pub enum FoodStallTagTag {
     #[serde(rename = "drink")]
     Drink,
 }
 
-impl Default for Tag {
-    fn default() -> Tag {
+impl Default for FoodStallTagTag {
+    fn default() -> FoodStallTagTag {
         Self::Drink
     }
 }
@@ -63,8 +62,7 @@ impl Default for Tag {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = FoodStallTagTag2)]
-pub enum Tag2 {
+pub enum FoodStallTagTag2 {
     #[serde(rename = "japanese")]
     Japanese,
     #[serde(rename = "western")]
@@ -79,8 +77,8 @@ pub enum Tag2 {
     World,
 }
 
-impl Default for Tag2 {
-    fn default() -> Tag2 {
+impl Default for FoodStallTagTag2 {
+    fn default() -> FoodStallTagTag2 {
         Self::Japanese
     }
 }

--- a/apps/backend/generated/events26_api/src/models/general_project.rs
+++ b/apps/backend/generated/events26_api/src/models/general_project.rs
@@ -28,7 +28,7 @@ pub struct GeneralProject {
     #[serde(rename = "occasions")]
     pub occasions: Vec<models::Occasion>,
     #[serde(rename = "type")]
-    pub r#type: Type,
+    pub r#type: GeneralProjectType,
     #[serde(rename = "tag")]
     pub tag: Vec<models::GeneralTag>,
 }
@@ -42,7 +42,7 @@ impl GeneralProject {
         is_child_friendly: bool,
         is_recommended: bool,
         occasions: Vec<models::Occasion>,
-        r#type: Type,
+        r#type: GeneralProjectType,
         tag: Vec<models::GeneralTag>,
     ) -> GeneralProject {
         GeneralProject {
@@ -72,14 +72,13 @@ impl GeneralProject {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = GeneralProjectType)]
-pub enum Type {
+pub enum GeneralProjectType {
     #[serde(rename = "general")]
     General,
 }
 
-impl Default for Type {
-    fn default() -> Type {
+impl Default for GeneralProjectType {
+    fn default() -> GeneralProjectType {
         Self::General
     }
 }

--- a/apps/backend/generated/events26_api/src/models/laboratory_project.rs
+++ b/apps/backend/generated/events26_api/src/models/laboratory_project.rs
@@ -28,7 +28,7 @@ pub struct LaboratoryProject {
     #[serde(rename = "occasions")]
     pub occasions: Vec<models::Occasion>,
     #[serde(rename = "type")]
-    pub r#type: Type,
+    pub r#type: LaboratoryProjectType,
     #[serde(rename = "isTour")]
     pub is_tour: bool,
 }
@@ -42,7 +42,7 @@ impl LaboratoryProject {
         is_child_friendly: bool,
         is_recommended: bool,
         occasions: Vec<models::Occasion>,
-        r#type: Type,
+        r#type: LaboratoryProjectType,
         is_tour: bool,
     ) -> LaboratoryProject {
         LaboratoryProject {
@@ -72,14 +72,13 @@ impl LaboratoryProject {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = LaboratoryProjectType)]
-pub enum Type {
+pub enum LaboratoryProjectType {
     #[serde(rename = "laboratory")]
     Laboratory,
 }
 
-impl Default for Type {
-    fn default() -> Type {
+impl Default for LaboratoryProjectType {
+    fn default() -> LaboratoryProjectType {
         Self::Laboratory
     }
 }

--- a/apps/backend/generated/events26_api/src/models/list_places_200_response_inner.rs
+++ b/apps/backend/generated/events26_api/src/models/list_places_200_response_inner.rs
@@ -14,9 +14,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ListPlaces200ResponseInner {
     #[serde(rename = "id")]
-    pub id: Id,
+    pub id: ListPlaces200ResponseInnerId,
     #[serde(rename = "type")]
-    pub r#type: Type,
+    pub r#type: ListPlaces200ResponseInnerType,
     #[serde(rename = "name")]
     pub name: String,
     #[serde(rename = "displayName")]
@@ -25,8 +25,8 @@ pub struct ListPlaces200ResponseInner {
 
 impl ListPlaces200ResponseInner {
     pub fn new(
-        id: Id,
-        r#type: Type,
+        id: ListPlaces200ResponseInnerId,
+        r#type: ListPlaces200ResponseInnerType,
         name: String,
         display_name: String,
     ) -> ListPlaces200ResponseInner {
@@ -52,8 +52,7 @@ impl ListPlaces200ResponseInner {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = ListPlaces200ResponseInnerId)]
-pub enum Id {
+pub enum ListPlaces200ResponseInnerId {
     #[serde(rename = "east")]
     East,
     #[serde(rename = "east.taki-plaza")]
@@ -586,8 +585,8 @@ pub enum Id {
     IshikawadaiFsIshikawadai7,
 }
 
-impl Default for Id {
-    fn default() -> Id {
+impl Default for ListPlaces200ResponseInnerId {
+    fn default() -> ListPlaces200ResponseInnerId {
         Self::East
     }
 }
@@ -605,8 +604,7 @@ impl Default for Id {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = ListPlaces200ResponseInnerType)]
-pub enum Type {
+pub enum ListPlaces200ResponseInnerType {
     #[serde(rename = "district")]
     District,
     #[serde(rename = "building")]
@@ -623,8 +621,8 @@ pub enum Type {
     FoodStallSlot,
 }
 
-impl Default for Type {
-    fn default() -> Type {
+impl Default for ListPlaces200ResponseInnerType {
+    fn default() -> ListPlaces200ResponseInnerType {
         Self::District
     }
 }

--- a/apps/backend/generated/events26_api/src/models/main_food_stall_tag.rs
+++ b/apps/backend/generated/events26_api/src/models/main_food_stall_tag.rs
@@ -14,13 +14,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct MainFoodStallTag {
     #[serde(rename = "tag")]
-    pub tag: Tag,
+    pub tag: MainFoodStallTagTag,
     #[serde(rename = "tag2")]
-    pub tag2: Tag2,
+    pub tag2: MainFoodStallTagTag2,
 }
 
 impl MainFoodStallTag {
-    pub fn new(tag: Tag, tag2: Tag2) -> MainFoodStallTag {
+    pub fn new(tag: MainFoodStallTagTag, tag2: MainFoodStallTagTag2) -> MainFoodStallTag {
         MainFoodStallTag { tag, tag2 }
     }
 }
@@ -38,14 +38,13 @@ impl MainFoodStallTag {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = MainFoodStallTagTag)]
-pub enum Tag {
+pub enum MainFoodStallTagTag {
     #[serde(rename = "main")]
     Main,
 }
 
-impl Default for Tag {
-    fn default() -> Tag {
+impl Default for MainFoodStallTagTag {
+    fn default() -> MainFoodStallTagTag {
         Self::Main
     }
 }
@@ -63,8 +62,7 @@ impl Default for Tag {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = MainFoodStallTagTag2)]
-pub enum Tag2 {
+pub enum MainFoodStallTagTag2 {
     #[serde(rename = "rice")]
     Rice,
     #[serde(rename = "noodle_flour")]
@@ -79,8 +77,8 @@ pub enum Tag2 {
     World,
 }
 
-impl Default for Tag2 {
-    fn default() -> Tag2 {
+impl Default for MainFoodStallTagTag2 {
+    fn default() -> MainFoodStallTagTag2 {
         Self::Rice
     }
 }

--- a/apps/backend/generated/events26_api/src/models/occasion.rs
+++ b/apps/backend/generated/events26_api/src/models/occasion.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct Occasion {
     #[serde(rename = "place", skip_serializing_if = "Option::is_none")]
-    pub place: Option<Place>,
+    pub place: Option<OccasionPlace>,
     #[serde(rename = "timeRange")]
     pub time_range: models::TimeRange,
 }
@@ -41,8 +41,7 @@ impl Occasion {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = OccasionPlace)]
-pub enum Place {
+pub enum OccasionPlace {
     #[serde(rename = "east")]
     East,
     #[serde(rename = "east.taki-plaza")]
@@ -575,8 +574,8 @@ pub enum Place {
     IshikawadaiFsIshikawadai7,
 }
 
-impl Default for Place {
-    fn default() -> Place {
+impl Default for OccasionPlace {
+    fn default() -> OccasionPlace {
         Self::East
     }
 }

--- a/apps/backend/generated/events26_api/src/models/outdoor.rs
+++ b/apps/backend/generated/events26_api/src/models/outdoor.rs
@@ -18,11 +18,11 @@ pub struct Outdoor {
     #[serde(rename = "displayName")]
     pub display_name: String,
     #[serde(rename = "type")]
-    pub r#type: Type,
+    pub r#type: OutdoorType,
 }
 
 impl Outdoor {
-    pub fn new(name: String, display_name: String, r#type: Type) -> Outdoor {
+    pub fn new(name: String, display_name: String, r#type: OutdoorType) -> Outdoor {
         Outdoor {
             name,
             display_name,
@@ -44,14 +44,13 @@ impl Outdoor {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = OutdoorType)]
-pub enum Type {
+pub enum OutdoorType {
     #[serde(rename = "outdoor")]
     Outdoor,
 }
 
-impl Default for Type {
-    fn default() -> Type {
+impl Default for OutdoorType {
+    fn default() -> OutdoorType {
         Self::Outdoor
     }
 }

--- a/apps/backend/generated/events26_api/src/models/place.rs
+++ b/apps/backend/generated/events26_api/src/models/place.rs
@@ -39,8 +39,7 @@ impl Default for Place {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = PlaceType)]
-pub enum Type {
+pub enum PlaceType {
     #[serde(rename = "district")]
     District,
     #[serde(rename = "food_stall_area")]
@@ -51,8 +50,8 @@ pub enum Type {
     FoodStallSlot,
 }
 
-impl Default for Type {
-    fn default() -> Type {
+impl Default for PlaceType {
+    fn default() -> PlaceType {
         Self::District
     }
 }

--- a/apps/backend/generated/events26_api/src/models/project.rs
+++ b/apps/backend/generated/events26_api/src/models/project.rs
@@ -39,8 +39,7 @@ impl Default for Project {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = ProjectType)]
-pub enum Type {
+pub enum ProjectType {
     #[serde(rename = "food-stall")]
     FoodStall,
     #[serde(rename = "general")]
@@ -51,8 +50,8 @@ pub enum Type {
     Stage,
 }
 
-impl Default for Type {
-    fn default() -> Type {
+impl Default for ProjectType {
+    fn default() -> ProjectType {
         Self::FoodStall
     }
 }

--- a/apps/backend/generated/events26_api/src/models/room.rs
+++ b/apps/backend/generated/events26_api/src/models/room.rs
@@ -18,7 +18,7 @@ pub struct Room {
     #[serde(rename = "displayName")]
     pub display_name: String,
     #[serde(rename = "type")]
-    pub r#type: Type,
+    pub r#type: RoomType,
     #[serde(rename = "floor")]
     pub floor: String,
     #[serde(rename = "alias", skip_serializing_if = "Option::is_none")]
@@ -26,7 +26,7 @@ pub struct Room {
 }
 
 impl Room {
-    pub fn new(name: String, display_name: String, r#type: Type, floor: String) -> Room {
+    pub fn new(name: String, display_name: String, r#type: RoomType, floor: String) -> Room {
         Room {
             name,
             display_name,
@@ -50,14 +50,13 @@ impl Room {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = RoomType)]
-pub enum Type {
+pub enum RoomType {
     #[serde(rename = "room")]
     Room,
 }
 
-impl Default for Type {
-    fn default() -> Type {
+impl Default for RoomType {
+    fn default() -> RoomType {
         Self::Room
     }
 }

--- a/apps/backend/generated/events26_api/src/models/stage.rs
+++ b/apps/backend/generated/events26_api/src/models/stage.rs
@@ -18,11 +18,11 @@ pub struct Stage {
     #[serde(rename = "displayName")]
     pub display_name: String,
     #[serde(rename = "type")]
-    pub r#type: Type,
+    pub r#type: StageType,
 }
 
 impl Stage {
-    pub fn new(name: String, display_name: String, r#type: Type) -> Stage {
+    pub fn new(name: String, display_name: String, r#type: StageType) -> Stage {
         Stage {
             name,
             display_name,
@@ -44,14 +44,13 @@ impl Stage {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = StageType)]
-pub enum Type {
+pub enum StageType {
     #[serde(rename = "stage")]
     Stage,
 }
 
-impl Default for Type {
-    fn default() -> Type {
+impl Default for StageType {
+    fn default() -> StageType {
         Self::Stage
     }
 }

--- a/apps/backend/generated/events26_api/src/models/stage_project.rs
+++ b/apps/backend/generated/events26_api/src/models/stage_project.rs
@@ -28,7 +28,7 @@ pub struct StageProject {
     #[serde(rename = "occasions")]
     pub occasions: Vec<models::Occasion>,
     #[serde(rename = "type")]
-    pub r#type: Type,
+    pub r#type: StageProjectType,
 }
 
 impl StageProject {
@@ -40,7 +40,7 @@ impl StageProject {
         is_child_friendly: bool,
         is_recommended: bool,
         occasions: Vec<models::Occasion>,
-        r#type: Type,
+        r#type: StageProjectType,
     ) -> StageProject {
         StageProject {
             id,
@@ -68,14 +68,13 @@ impl StageProject {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = StageProjectType)]
-pub enum Type {
+pub enum StageProjectType {
     #[serde(rename = "stage")]
     Stage,
 }
 
-impl Default for Type {
-    fn default() -> Type {
+impl Default for StageProjectType {
+    fn default() -> StageProjectType {
         Self::Stage
     }
 }

--- a/apps/backend/generated/events26_api/src/models/sweet_food_stall_tag.rs
+++ b/apps/backend/generated/events26_api/src/models/sweet_food_stall_tag.rs
@@ -14,13 +14,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct SweetFoodStallTag {
     #[serde(rename = "tag")]
-    pub tag: Tag,
+    pub tag: SweetFoodStallTagTag,
     #[serde(rename = "tag2")]
-    pub tag2: Tag2,
+    pub tag2: SweetFoodStallTagTag2,
 }
 
 impl SweetFoodStallTag {
-    pub fn new(tag: Tag, tag2: Tag2) -> SweetFoodStallTag {
+    pub fn new(tag: SweetFoodStallTagTag, tag2: SweetFoodStallTagTag2) -> SweetFoodStallTag {
         SweetFoodStallTag { tag, tag2 }
     }
 }
@@ -38,14 +38,13 @@ impl SweetFoodStallTag {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = SweetFoodStallTagTag)]
-pub enum Tag {
+pub enum SweetFoodStallTagTag {
     #[serde(rename = "sweet")]
     Sweet,
 }
 
-impl Default for Tag {
-    fn default() -> Tag {
+impl Default for SweetFoodStallTagTag {
+    fn default() -> SweetFoodStallTagTag {
         Self::Sweet
     }
 }
@@ -63,8 +62,7 @@ impl Default for Tag {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = SweetFoodStallTagTag2)]
-pub enum Tag2 {
+pub enum SweetFoodStallTagTag2 {
     #[serde(rename = "japanese")]
     Japanese,
     #[serde(rename = "western")]
@@ -79,8 +77,8 @@ pub enum Tag2 {
     World,
 }
 
-impl Default for Tag2 {
-    fn default() -> Tag2 {
+impl Default for SweetFoodStallTagTag2 {
+    fn default() -> SweetFoodStallTagTag2 {
         Self::Japanese
     }
 }

--- a/apps/backend/generated/events26_api/src/models/time.rs
+++ b/apps/backend/generated/events26_api/src/models/time.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct Time {
     #[serde(rename = "date")]
-    pub date: Date,
+    pub date: TimeDate,
     #[serde(rename = "hour")]
     pub hour: f64,
     #[serde(rename = "minute")]
@@ -22,11 +22,12 @@ pub struct Time {
 }
 
 impl Time {
-    pub fn new(date: Date, hour: f64, minute: f64) -> Time {
+    pub fn new(date: TimeDate, hour: f64, minute: f64) -> Time {
         Time { date, hour, minute }
     }
 }
 ///
+#[repr(i64)]
 #[derive(
     Clone,
     Copy,
@@ -36,20 +37,30 @@ impl Time {
     Ord,
     PartialOrd,
     Hash,
-    Serialize,
-    Deserialize,
+    serde_repr::Serialize_repr,
+    serde_repr::Deserialize_repr,
     utoipa::ToSchema,
 )]
-#[schema(as = TimeDate)]
-pub enum Date {
-    #[serde(rename = "1")]
-    Variant1,
-    #[serde(rename = "2")]
-    Variant2,
+pub enum TimeDate {
+    Variant1 = 1,
+    Variant2 = 2,
 }
 
-impl Default for Date {
-    fn default() -> Date {
+impl std::fmt::Display for TimeDate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Variant1 => "1",
+                Self::Variant2 => "2",
+            }
+        )
+    }
+}
+
+impl Default for TimeDate {
+    fn default() -> TimeDate {
         Self::Variant1
     }
 }

--- a/apps/backend/generated/events26_api/src/models/venue.rs
+++ b/apps/backend/generated/events26_api/src/models/venue.rs
@@ -39,8 +39,7 @@ impl Default for Venue {
     Deserialize,
     utoipa::ToSchema,
 )]
-#[schema(as = VenueType)]
-pub enum Type {
+pub enum VenueType {
     #[serde(rename = "building")]
     Building,
     #[serde(rename = "stage")]
@@ -51,8 +50,8 @@ pub enum Type {
     FoodStallArea,
 }
 
-impl Default for Type {
-    fn default() -> Type {
+impl Default for VenueType {
+    fn default() -> VenueType {
         Self::Building
     }
 }

--- a/apps/backend/openapi-templates/README.md
+++ b/apps/backend/openapi-templates/README.md
@@ -20,8 +20,17 @@ generator を上げたときは、内蔵テンプレートを取り直して同�
     unzip -j <openapi-generator-cli.jar> 'rust/model.mustache' 'rust/Cargo.mustache'
 
 - `model.mustache`: 全 `#[derive(...)]` に `utoipa::ToSchema` を追加
-- `model.mustache`: プロパティ由来の enum に `#[schema(as = {{classname}}{{{enumName}}})]` を追加。
-  生成される内側の enum は `Type` / `Tag` のように名前が重複し、utoipa は型名を
-  そのままスキーマ名にするため、これが無いと components 上で互いに上書きし合う
-  (例: `FoodStallProject.type` が `enum: ["stage"]` として公開されてしまう)。
-- `Cargo.mustache`: 依存に `utoipa = "^5.5"` を追加
+- `model.mustache`: プロパティ由来の enum の型名を `{{{enumName}}}` から
+  `{{classname}}{{{enumName}}}` に変更。内蔵テンプレートのままだと `Type` / `Tag` の
+  ように名前が重複し、utoipa は型名をそのままスキーマ名にするため components 上で
+  互いに上書きし合う(例: `FoodStallProject.type` が `enum: ["stage"]` として
+  公開されてしまう)。あわせて utoipa が既知の型として特別扱いする識別子との衝突も
+  避けられる(`Time.date` の enum が `Date` という名前になり、日付型と解釈されて
+  `{"type":"string","format":"date"}` として公開されていた)。
+- `model.mustache`: プロパティ由来の enum の数値判定を `isInteger` から `isNumeric` に
+  変更。`type: number` の enum(events26 の `Time.date` は `enum: [1, 2]`)が文字列
+  enum として生成され、`"1"` / `"2"` と送ってしまっていたため。
+  `serde_repr` は import ではなくパス指定で使う。ファイル先頭の `use` は
+  `x-rust-has-integer-property-enum` で切られており `type: number` では入らない。
+- `Cargo.mustache`: 依存に `utoipa = "^5.5"` を追加。数値 enum を変種名ではなく
+  実際の数値としてスキーマに出すため `repr` フィーチャを有効にしている。

--- a/apps/backend/openapi-templates/rust/Cargo.mustache
+++ b/apps/backend/openapi-templates/rust/Cargo.mustache
@@ -38,7 +38,9 @@ serde_with = { version = "^3.8", default-features = false, features = ["base64",
 {{/serdeWith}}
 serde_json = "^1.0"
 serde_repr = "^0.1"
-utoipa = "^5.5"
+# repr: 数値 enum のプロパティ(serde_repr + #[repr(i64)])を、変種名ではなく
+# 実際の数値としてスキーマに出すために要る。
+utoipa = { version = "^5.5", features = ["repr"] }
 {{#useSerdePathToError}}
 serde_path_to_error = "^0.1"
 {{/useSerdePathToError}}

--- a/apps/backend/openapi-templates/rust/model.mustache
+++ b/apps/backend/openapi-templates/rust/model.mustache
@@ -90,7 +90,7 @@ pub enum {{{classname}}} {
         /// {{{.}}}
         {{/description}}
         #[serde(rename = "{{{baseName}}}"{{^required}}, skip_serializing_if = "Option::is_none"{{/required}})]
-        {{{name}}}: {{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{^required}}Option<{{/required}}{{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{#isModel}}{{^avoidBoxedModels}}Box<{{/avoidBoxedModels}}{{{dataType}}}{{^avoidBoxedModels}}>{{/avoidBoxedModels}}{{/isModel}}{{^isModel}}{{{dataType}}}{{/isModel}}{{/isEnum}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{^required}}>{{/required}},
+        {{{name}}}: {{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{^required}}Option<{{/required}}{{#isEnum}}{{classname}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{#isModel}}{{^avoidBoxedModels}}Box<{{/avoidBoxedModels}}{{{dataType}}}{{^avoidBoxedModels}}>{{/avoidBoxedModels}}{{/isModel}}{{^isModel}}{{{dataType}}}{{/isModel}}{{/isEnum}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{^required}}>{{/required}},
     {{/vars}}
     },
     {{/mappedModels}}
@@ -138,7 +138,7 @@ pub struct {{{classname}}} {
     ### Option Start
     }}{{#isNullable}}Option<{{/isNullable}}{{^required}}Option<{{/required}}{{!
     ### Enums
-    }}{{#isEnum}}{{#isArray}}{{#uniqueItems}}std::collections::HashSet<{{/uniqueItems}}{{^uniqueItems}}Vec<{{/uniqueItems}}{{/isArray}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{!
+    }}{{#isEnum}}{{#isArray}}{{#uniqueItems}}std::collections::HashSet<{{/uniqueItems}}{{^uniqueItems}}Vec<{{/uniqueItems}}{{/isArray}}{{classname}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{!
     ### Non-Enums Start
     }}{{^isEnum}}{{!
     ### Models
@@ -160,7 +160,7 @@ impl {{{classname}}} {
     ### Option Start
     }}{{#isNullable}}Option<{{/isNullable}}{{!
     ### Enums
-    }}{{#isEnum}}{{#isArray}}{{#uniqueItems}}std::collections::HashSet<{{/uniqueItems}}{{^uniqueItems}}Vec<{{/uniqueItems}}{{/isArray}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{!
+    }}{{#isEnum}}{{#isArray}}{{#uniqueItems}}std::collections::HashSet<{{/uniqueItems}}{{^uniqueItems}}Vec<{{/uniqueItems}}{{/isArray}}{{classname}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{!
     ### Non-Enums
     }}{{^isEnum}}{{#isByteArray}}Vec<u8>{{/isByteArray}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}{{/isEnum}}{{!
     ### Option End
@@ -202,12 +202,14 @@ impl Default for {{classname}} {
 {{!-- for properties that are of enum type --}}
 {{#vars}}
 {{#isEnum}}
-{{#isInteger}}
+{{#isNumeric}}
 /// {{{description}}}
 #[repr(i64)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize_repr, Deserialize_repr, utoipa::ToSchema)]
-#[schema(as = {{classname}}{{{enumName}}})]
-pub enum {{{enumName}}} {
+{{!-- serde_repr は import ではなくパス指定で使う。ファイル先頭の use は
+     x-rust-has-integer-property-enum(integer のみ)で切られており、
+     type: number の enum ではここに来ても import されないため。 --}}
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, serde_repr::Serialize_repr, serde_repr::Deserialize_repr, utoipa::ToSchema)]
+pub enum {{classname}}{{{enumName}}} {
 {{#allowableValues}}
 {{#enumVars}}
     {{{name}}} = {{{value}}},
@@ -215,7 +217,7 @@ pub enum {{{enumName}}} {
 {{/allowableValues}}
 }
 
-impl std::fmt::Display for {{{enumName}}} {
+impl std::fmt::Display for {{classname}}{{{enumName}}} {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", match self {
             {{#allowableValues}}
@@ -226,12 +228,11 @@ impl std::fmt::Display for {{{enumName}}} {
         })
     }
 }
-{{/isInteger}}
-{{^isInteger}}
+{{/isNumeric}}
+{{^isNumeric}}
 /// {{{description}}}
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, utoipa::ToSchema)]
-#[schema(as = {{classname}}{{{enumName}}})]
-pub enum {{{enumName}}} {
+pub enum {{classname}}{{{enumName}}} {
 {{#allowableValues}}
 {{#enumVars}}
     #[serde(rename = "{{{value}}}")]
@@ -239,10 +240,10 @@ pub enum {{{enumName}}} {
 {{/enumVars}}
 {{/allowableValues}}
 }
-{{/isInteger}}
+{{/isNumeric}}
 
-impl Default for {{{enumName}}} {
-    fn default() -> {{{enumName}}} {
+impl Default for {{classname}}{{{enumName}}} {
+    fn default() -> {{classname}}{{{enumName}}} {
         {{#allowableValues}}
         Self::{{ enumVars.0.name }}
         {{/allowableValues}}

--- a/docs/api/api_v3/openapi.json
+++ b/docs/api/api_v3/openapi.json
@@ -3414,8 +3414,7 @@
         "required": ["date", "hour", "minute"],
         "properties": {
           "date": {
-            "type": "string",
-            "format": "date"
+            "$ref": "#/components/schemas/TimeDate"
           },
           "hour": {
             "type": "number",
@@ -3426,6 +3425,11 @@
             "format": "double"
           }
         }
+      },
+      "TimeDate": {
+        "type": "integer",
+        "description": "",
+        "enum": [1, 2]
       },
       "TimeRange": {
         "type": "object",

--- a/libs/shared-types/src/api_v3.d.ts
+++ b/libs/shared-types/src/api_v3.d.ts
@@ -1163,13 +1163,14 @@ export interface components {
       | 'drink'
       | 'world';
     Time: {
-      /** Format: date */
-      date: string;
+      date: components['schemas']['TimeDate'];
       /** Format: double */
       hour: number;
       /** Format: double */
       minute: number;
     };
+    /** @enum {integer} */
+    TimeDate: 1 | 2;
     TimeRange: {
       end: components['schemas']['Time'];
       start: components['schemas']['Time'];


### PR DESCRIPTION
> #444 に積んでいます。マージ順に注意してください。

## 問題

events26 の `Time.date` は `enum: [1, 2]` の数値ですが、`/api/v3/events26` の中継では文字列 `"1"` / `"2"` として送られ、ポータルの OpenAPI 上も `{"type":"string","format":"date"}` として公開されていました。**この状態では企画の作成・置換が上流に弾かれます。**

## 原因と修正

openapi-generator の rust テンプレート 2 点です。

**1. 数値判定が `isInteger` だった** — events26 の spec は `type: number` で宣言しており `integer` ではないため、`repr(i64)` + `serde_repr` の分岐に入らず文字列 enum として生成されていました。`isNumeric` に変えて `number` も拾います。

`serde_repr` は import ではなくパス指定に変えました。ファイル先頭の `use` は `x-rust-has-integer-property-enum`（integer のみ）で切られており、`type: number` ではここに来ても import されないためです。

**2. プロパティ由来の enum の型名** — 生成される型名が `Date` で、utoipa がこれを既知の日付型として特別扱いし `format: date` として公開していました。型名自体を `{{classname}}{{{enumName}}}` にして衝突を避けます（`Time.date` なら `TimeDate`）。

これは元々 `#[schema(as = ...)]` で回避していたスキーマ名の重複も型名の側で解消するので、`schema(as)` は不要になり落としました。

**3. `utoipa` の `repr` フィーチャ** — 無いと repr enum が変種名（`["Variant1","Variant2"]`）として公開されます。生成クレートの `Cargo.toml` に追加。

## 結果

```diff
     Time: {
-      /** Format: date */
-      date: string;
+      date: components['schemas']['TimeDate'];
       hour: number;
       minute: number;
     };
+    /** @enum {integer} */
+    TimeDate: 1 | 2;
```

events26 の `1 | 2` と一致するようになったので、admin 側で送信時にかけていたキャストも外しました（`tsc` が通ることが型の一致の裏付けになっています）。

生成スキーマの差分は `Time` / `TimeDate` のみで、他のスキーマは追加・削除・変更いずれもありません（`components.schemas` を全件比較して確認）。

## 確認

- `cargo clippy --all-targets --all-features` ✅
- `cargo test` ✅ (528 passed)
- `npx tsc -b apps/admin/tsconfig.json` ✅（キャストを外した状態で通る）
- `npx nx run-many -t lint -p admin portal` ✅
- `npx nx build admin` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)