### PR TITLE
feat(admin): 企画情報を1件ずつ編集する画面を追加する

### DIFF
--- a/apps/admin/src/features/events26/EditProjectPage.tsx
+++ b/apps/admin/src/features/events26/EditProjectPage.tsx
@@ -1,0 +1,576 @@
+import {
+  DeleteOutlined,
+  MinusCircleOutlined,
+  PlusOutlined,
+  UploadOutlined,
+} from '@ant-design/icons';
+import { LoadingScreen } from '@koudaisai/shared-ui';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  Button,
+  Card,
+  Checkbox,
+  Divider,
+  Flex,
+  Form,
+  Input,
+  message,
+  Popconfirm,
+  Result,
+  Select,
+  Space,
+  Upload,
+} from 'antd';
+import { useEffect, useMemo, useState } from 'react';
+import { api, $events26Api } from '@/features/api/api';
+import {
+  ensureOk,
+  FOOD_STALL_TAG2,
+  formatTime,
+  GENERAL_TAGS,
+  ICON_CONTENT_TYPES,
+  iconUrl,
+  parseTime,
+  PROJECT_TYPE_LABEL,
+  putIcon,
+} from './project';
+import type {
+  FoodStallTag,
+  GeneralTag,
+  Occasion,
+  Place,
+  Project,
+  Time,
+} from './project';
+
+/** 開催予定 1 件分。時刻は CSV と同じ `HH:mm` の文字列で持つ。 */
+type OccasionValues = {
+  date: Time['date'];
+  place?: Place;
+  start: string;
+  end: string;
+};
+
+/** 模擬店タグ 1 件分。`drink` は `tag2` を持たない。 */
+type FoodStallTagValues = {
+  tag: FoodStallTag['tag'];
+  tag2?: string;
+};
+
+type FormValues = {
+  type: Project['type'];
+  groupName: string;
+  projectName: string;
+  description: string;
+  isChildFriendly: boolean;
+  isRecommended: boolean;
+  /** 研究室公開企画のみ。 */
+  isTour?: boolean;
+  /** 模擬店企画のみ。 */
+  foodStallTags?: FoodStallTagValues[];
+  /** 一般企画のみ。 */
+  generalTags?: GeneralTag[];
+  occasions?: OccasionValues[];
+};
+
+const TIME_RULE = {
+  pattern: /^([01]?\d|2[0-3]):[0-5]\d$/,
+  message: 'HH:mm 形式で入力してください',
+};
+
+const PROJECT_TYPE_OPTIONS = Object.entries(PROJECT_TYPE_LABEL).map(
+  ([value, { text }]) => ({ value, label: `${text}（${value}）` }),
+);
+
+const FOOD_STALL_TAG_OPTIONS: { value: FoodStallTag['tag']; label: string }[] =
+  [
+    { value: 'main', label: 'main（主食）' },
+    { value: 'sweet', label: 'sweet（スイーツ）' },
+    { value: 'drink', label: 'drink（ドリンク）' },
+  ];
+
+function toFormValues(project: Project): FormValues {
+  return {
+    type: project.type,
+    groupName: project.groupName,
+    projectName: project.projectName,
+    description: project.description,
+    isChildFriendly: project.isChildFriendly,
+    isRecommended: project.isRecommended,
+    isTour: project.type === 'laboratory' ? project.isTour : undefined,
+    foodStallTags:
+      project.type === 'food-stall'
+        ? project.tag.map((tag) =>
+            'tag2' in tag ? { tag: tag.tag, tag2: tag.tag2 } : { tag: tag.tag },
+          )
+        : undefined,
+    generalTags: project.type === 'general' ? project.tag : undefined,
+    occasions: project.occasions.map((occasion) => ({
+      date: occasion.timeRange.start.date,
+      place: occasion.place,
+      start: formatTime(occasion.timeRange.start),
+      end: formatTime(occasion.timeRange.end),
+    })),
+  };
+}
+
+function buildOccasions(values: OccasionValues[]): Occasion[] {
+  return values.map((occasion) => ({
+    // 未指定は null ではなくキーごと省く(spec 上 optional であって nullable ではない)。
+    ...(occasion.place ? { place: occasion.place } : {}),
+    timeRange: {
+      start: parseTime(occasion.date, occasion.start),
+      end: parseTime(occasion.date, occasion.end),
+    },
+  }));
+}
+
+function buildFoodStallTags(values: FoodStallTagValues[]): FoodStallTag[] {
+  return values.map((value) => {
+    if (value.tag === 'drink') return { tag: 'drink' };
+    if (!value.tag2) {
+      throw new Error(`模擬店タグ ${value.tag} には tag2 が必要です`);
+    }
+    return { tag: value.tag, tag2: value.tag2 } as FoodStallTag;
+  });
+}
+
+/**
+ * 入力値を [`Project`] にする。
+ *
+ * PUT は差分更新ではなく全置き換えなので、種別を変えたときは元の種別だけが持つ
+ * 項目(タグ・ラボツアー)は送らずに落とす。
+ */
+function buildProject(id: string, values: FormValues): Project {
+  const base = {
+    id,
+    groupName: values.groupName,
+    projectName: values.projectName,
+    description: values.description,
+    isChildFriendly: values.isChildFriendly ?? false,
+    isRecommended: values.isRecommended ?? false,
+    occasions: buildOccasions(values.occasions ?? []),
+  };
+
+  switch (values.type) {
+    case 'food-stall':
+      return {
+        ...base,
+        type: 'food-stall',
+        tag: buildFoodStallTags(values.foodStallTags ?? []),
+      };
+    case 'general':
+      return { ...base, type: 'general', tag: values.generalTags ?? [] };
+    case 'stage':
+      return { ...base, type: 'stage' };
+    case 'laboratory':
+      return { ...base, type: 'laboratory', isTour: values.isTour ?? false };
+  }
+}
+
+export function EditProjectPage() {
+  const [queryClient] = useState(() => new QueryClient());
+  const [projectId, setProjectId] = useState<string | null>();
+
+  useEffect(() => {
+    setProjectId(new URLSearchParams(window.location.search).get('project_id'));
+  }, []);
+
+  if (projectId === undefined) {
+    return <LoadingScreen />;
+  }
+
+  if (!projectId) {
+    return (
+      <Result
+        status="error"
+        title="クエリパラメータに不足があります"
+        subTitle="企画番号が指定されていません。URLに?project_id=M-001のように指定してください。"
+        extra={
+          <Button href="/events26" type="primary">
+            戻る
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <EditProjectForm projectId={projectId} />
+    </QueryClientProvider>
+  );
+}
+
+function EditProjectForm({ projectId }: { projectId: string }) {
+  const [form] = Form.useForm<FormValues>();
+  const [messageApi, contextHolder] = message.useMessage();
+  // 1 件の取得は backend に中継が無いので events26 の公開エンドポイントを直接読む。
+  const {
+    data: project,
+    isLoading,
+    error,
+    refetch,
+  } = $events26Api.useQuery('get', '/v1/projects/{projectId}', {
+    params: { path: { projectId } },
+  });
+  const { data: places } = $events26Api.useQuery('get', '/v1/places');
+  const [submitting, setSubmitting] = useState(false);
+  // アイコンは URL が同じまま中身だけ変わるので、更新後はこの値を進めて再取得させる。
+  const [iconVersion, setIconVersion] = useState(0);
+
+  const placeOptions = useMemo(
+    () =>
+      places?.map((place) => ({
+        value: place.id,
+        label: `${place.displayName}（${place.id}）`,
+      })) ?? [],
+    [places],
+  );
+
+  // 種別で出し入れする項目のために監視する。初回描画では値が入らないので、
+  // 取得済みの企画の種別を既定にしてちらつきを避ける。
+  const watchedType = Form.useWatch('type', form);
+
+  if (isLoading) {
+    return <LoadingScreen />;
+  }
+
+  if (!project) {
+    return (
+      <Result
+        status="error"
+        title="データを取得できませんでした"
+        subTitle={String(error)}
+        extra={
+          <Button href="/events26" type="primary">
+            戻る
+          </Button>
+        }
+      />
+    );
+  }
+
+  const type = watchedType ?? project.type;
+
+  const handleSubmit = async (values: FormValues) => {
+    setSubmitting(true);
+    try {
+      ensureOk(
+        await api.PUT('/events26/projects/{project_id}', {
+          params: { path: { project_id: projectId } },
+          body: buildProject(projectId, values),
+        }),
+        '企画情報の更新',
+      );
+      messageApi.success('保存しました');
+      await refetch();
+    } catch (e) {
+      console.error(e);
+      messageApi.error(`保存に失敗しました: ${String(e)}`);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleIconUpload = async (file: File) => {
+    if (!ICON_CONTENT_TYPES.includes(file.type)) {
+      messageApi.error(`対応外のアイコン形式です（${file.type}）`);
+      return;
+    }
+    try {
+      await putIcon(projectId, file);
+      setIconVersion((version) => version + 1);
+      messageApi.success('アイコンをアップロードしました');
+    } catch (e) {
+      console.error(e);
+      messageApi.error(`アイコンのアップロードに失敗しました: ${String(e)}`);
+    }
+  };
+
+  const handleIconDelete = async () => {
+    try {
+      ensureOk(
+        await api.DELETE('/events26/projects/{project_id}/icon', {
+          params: { path: { project_id: projectId } },
+        }),
+        'アイコンの削除',
+      );
+      setIconVersion((version) => version + 1);
+      messageApi.success('アイコンを削除しました');
+    } catch (e) {
+      console.error(e);
+      messageApi.error(`アイコンの削除に失敗しました: ${String(e)}`);
+    }
+  };
+
+  return (
+    <>
+      <h1>企画情報を編集</h1>
+      <Form
+        form={form}
+        layout="vertical"
+        onFinish={handleSubmit}
+        initialValues={toFormValues(project)}
+      >
+        <Form.Item label="企画番号">
+          {/* id は events26 側のキーで、置き換えでは変えられない。 */}
+          <Input value={projectId} disabled />
+        </Form.Item>
+        <Form.Item
+          name="type"
+          label="種類"
+          rules={[{ required: true, message: '種類を選択してください' }]}
+        >
+          <Select options={PROJECT_TYPE_OPTIONS} />
+        </Form.Item>
+        <Form.Item
+          name="groupName"
+          label="団体名"
+          rules={[{ required: true, message: '団体名を入力してください' }]}
+        >
+          <Input />
+        </Form.Item>
+        <Form.Item
+          name="projectName"
+          label="企画名"
+          rules={[{ required: true, message: '企画名を入力してください' }]}
+        >
+          <Input />
+        </Form.Item>
+        <Form.Item
+          name="description"
+          label="概要"
+          rules={[{ required: true, message: '概要を入力してください' }]}
+        >
+          <Input.TextArea autoSize={{ minRows: 3 }} />
+        </Form.Item>
+        <Form.Item name="isChildFriendly" valuePropName="checked">
+          <Checkbox>子供向け企画</Checkbox>
+        </Form.Item>
+        <Form.Item name="isRecommended" valuePropName="checked">
+          <Checkbox>おすすめ企画</Checkbox>
+        </Form.Item>
+
+        {type === 'laboratory' && (
+          <Form.Item name="isTour" valuePropName="checked">
+            <Checkbox>ラボツアー</Checkbox>
+          </Form.Item>
+        )}
+
+        {type === 'general' && (
+          <Form.Item name="generalTags" label="タグ">
+            <Select
+              mode="multiple"
+              allowClear
+              options={GENERAL_TAGS.map((tag) => ({ value: tag, label: tag }))}
+              placeholder="タグを選択"
+            />
+          </Form.Item>
+        )}
+
+        {type === 'food-stall' && (
+          <Form.Item label="タグ">
+            <Form.List name="foodStallTags">
+              {(fields, { add, remove }) => (
+                <Flex gap={8} vertical>
+                  {fields.map((field) => (
+                    <Space key={field.key} align="baseline">
+                      <Form.Item
+                        name={[field.name, 'tag']}
+                        noStyle
+                        rules={[{ required: true, message: 'tag は必須です' }]}
+                      >
+                        <Select
+                          style={{ width: 180 }}
+                          options={FOOD_STALL_TAG_OPTIONS}
+                          placeholder="tag"
+                          onChange={() => {
+                            // tag を変えると選べる tag2 も変わるので、古い値を残さない。
+                            const tags =
+                              form.getFieldValue('foodStallTags') ?? [];
+                            tags[field.name] = {
+                              ...tags[field.name],
+                              tag2: undefined,
+                            };
+                            form.setFieldValue('foodStallTags', [...tags]);
+                          }}
+                        />
+                      </Form.Item>
+                      <Form.Item
+                        noStyle
+                        shouldUpdate={(prev, next) =>
+                          prev.foodStallTags?.[field.name]?.tag !==
+                          next.foodStallTags?.[field.name]?.tag
+                        }
+                      >
+                        {({ getFieldValue }) => {
+                          const tag: FoodStallTag['tag'] | undefined =
+                            getFieldValue(['foodStallTags', field.name, 'tag']);
+                          if (!tag || tag === 'drink') return null;
+                          return (
+                            <Form.Item
+                              name={[field.name, 'tag2']}
+                              noStyle
+                              rules={[
+                                { required: true, message: 'tag2 は必須です' },
+                              ]}
+                            >
+                              <Select
+                                style={{ width: 180 }}
+                                options={FOOD_STALL_TAG2[tag].map((value) => ({
+                                  value,
+                                  label: value,
+                                }))}
+                                placeholder="tag2"
+                              />
+                            </Form.Item>
+                          );
+                        }}
+                      </Form.Item>
+                      <MinusCircleOutlined onClick={() => remove(field.name)} />
+                    </Space>
+                  ))}
+                  <Form.Item noStyle>
+                    <Button
+                      type="dashed"
+                      onClick={() => add({ tag: 'main' })}
+                      block
+                      icon={<PlusOutlined />}
+                    >
+                      タグを追加
+                    </Button>
+                  </Form.Item>
+                </Flex>
+              )}
+            </Form.List>
+          </Form.Item>
+        )}
+
+        <Form.Item label="開催予定">
+          <Form.List name="occasions">
+            {(fields, { add, remove }) => (
+              <Flex gap={8} vertical>
+                {fields.map((field) => (
+                  <Space key={field.key} align="baseline" wrap>
+                    <Form.Item
+                      name={[field.name, 'date']}
+                      noStyle
+                      rules={[{ required: true, message: '日を選択' }]}
+                    >
+                      <Select
+                        style={{ width: 110 }}
+                        options={[
+                          { value: 1, label: '1日目' },
+                          { value: 2, label: '2日目' },
+                        ]}
+                      />
+                    </Form.Item>
+                    <Form.Item
+                      name={[field.name, 'start']}
+                      noStyle
+                      rules={[
+                        { required: true, message: '開始時刻は必須です' },
+                        TIME_RULE,
+                      ]}
+                    >
+                      <Input style={{ width: 100 }} placeholder="10:00" />
+                    </Form.Item>
+                    <Form.Item
+                      name={[field.name, 'end']}
+                      noStyle
+                      rules={[
+                        { required: true, message: '終了時刻は必須です' },
+                        TIME_RULE,
+                      ]}
+                    >
+                      <Input style={{ width: 100 }} placeholder="17:00" />
+                    </Form.Item>
+                    <Form.Item name={[field.name, 'place']} noStyle>
+                      <Select
+                        style={{ width: 360 }}
+                        options={placeOptions}
+                        placeholder="実施場所（任意）"
+                        showSearch
+                        allowClear
+                        optionFilterProp="label"
+                      />
+                    </Form.Item>
+                    <MinusCircleOutlined onClick={() => remove(field.name)} />
+                  </Space>
+                ))}
+                <Form.Item noStyle>
+                  <Button
+                    type="dashed"
+                    onClick={() => add({ date: 1 })}
+                    block
+                    icon={<PlusOutlined />}
+                  >
+                    開催予定を追加
+                  </Button>
+                </Form.Item>
+              </Flex>
+            )}
+          </Form.List>
+        </Form.Item>
+
+        <Form.Item>
+          <Flex gap={8}>
+            <Button type="primary" htmlType="submit" disabled={submitting}>
+              保存
+            </Button>
+            <Button type="default" href="/events26">
+              戻る
+            </Button>
+          </Flex>
+        </Form.Item>
+      </Form>
+
+      <Divider />
+
+      {/* アイコンは企画本体とは別の API なので、フォームの保存とは独立して更新する。 */}
+      <Card title="アイコン" size="small" style={{ maxWidth: 480 }}>
+        <Flex gap={16} align="center" wrap>
+          <img
+            src={iconUrl(projectId, iconVersion)}
+            alt="企画のアイコン"
+            width={96}
+            height={96}
+            // 未登録の企画は 404 になる。壊れた画像アイコンを出さずに隠す。
+            onError={(event) => {
+              event.currentTarget.style.visibility = 'hidden';
+            }}
+          />
+          <Flex gap={8} vertical>
+            <Upload
+              maxCount={1}
+              showUploadList={false}
+              accept={ICON_CONTENT_TYPES.join(',')}
+              beforeUpload={async (file) => {
+                await handleIconUpload(file);
+                return false;
+              }}
+            >
+              <Button icon={<UploadOutlined />}>アイコンをアップロード</Button>
+            </Upload>
+            <Popconfirm
+              title="アイコンを削除"
+              description="この企画のアイコンを削除しますか？"
+              onConfirm={handleIconDelete}
+              okText="はい"
+              cancelText="いいえ"
+            >
+              <Button danger icon={<DeleteOutlined />}>
+                アイコンを削除
+              </Button>
+            </Popconfirm>
+          </Flex>
+        </Flex>
+        <p style={{ marginBottom: 0, color: '#888' }}>
+          対応形式は png / jpeg / gif / webp / heic、正方形で 20MB 以下です。
+        </p>
+      </Card>
+      {contextHolder}
+    </>
+  );
+}

--- a/apps/admin/src/features/events26/Events26Page.tsx
+++ b/apps/admin/src/features/events26/Events26Page.tsx
@@ -1,10 +1,10 @@
 import {
   DeleteOutlined,
   DownloadOutlined,
+  EditOutlined,
   FolderOpenOutlined,
   UploadOutlined,
 } from '@ant-design/icons';
-import type { events26Components } from '@koudaisai/shared-types';
 import { Heading1, LoadingScreen } from '@koudaisai/shared-ui';
 import { useDownload } from '@koudaisai/shared-utils';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -23,15 +23,26 @@ import type { TableProps } from 'antd';
 import objectHash from 'object-hash';
 import Papa from 'papaparse';
 import { useRef, useState } from 'react';
-import { EVENTS26_API_URL } from 'astro:env/client';
 import { api, $events26Api } from '@/features/api/api';
-
-type Project = events26Components['schemas']['Project'];
-type Occasion = events26Components['schemas']['Occasion'];
-type Place = NonNullable<Occasion['place']>;
-type Time = events26Components['schemas']['Time'];
-type FoodStallTag = events26Components['schemas']['FoodStallTag'];
-type GeneralTag = events26Components['schemas']['GeneralTag'];
+import {
+  ensureOk,
+  formatTags,
+  formatTime,
+  GENERAL_TAGS,
+  ICON_CONTENT_TYPES,
+  iconUrl,
+  parseTime,
+  PROJECT_TYPE_LABEL,
+  putIcon,
+} from './project';
+import type {
+  FoodStallTag,
+  GeneralTag,
+  Occasion,
+  Place,
+  Project,
+  Time,
+} from './project';
 
 /** CSV の 1 行。すべての列を文字列として読み書きする。 */
 type ProjectRow = {
@@ -100,44 +111,8 @@ const CSV_COLUMNS: (keyof ProjectRow)[] = [
   'day2_end',
 ];
 
-const PROJECT_TYPE_LABEL: Record<
-  Project['type'],
-  { text: string; color: string }
-> = {
-  'food-stall': { text: '模擬店企画', color: 'red' },
-  general: { text: '一般企画', color: 'blue' },
-  stage: { text: 'ステージ企画', color: 'green' },
-  laboratory: { text: '研究室公開企画', color: 'orange' },
-};
-
-const GENERAL_TAGS: GeneralTag[] = [
-  'experience',
-  'display',
-  'performance',
-  'food',
-  'lecture',
-];
-
 function parseBoolean(value: string): boolean {
   return value.trim().toLowerCase() === 'true';
-}
-
-/** `HH:MM` を `date` 日目の [`Time`] に変換する。 */
-function parseTime(date: Time['date'], value: string): Time {
-  const match = /^(\d{1,2}):(\d{2})$/.exec(value.trim());
-  if (!match) {
-    throw new Error(`時刻は HH:MM 形式で指定してください: ${value}`);
-  }
-  const hour = Number(match[1]);
-  const minute = Number(match[2]);
-  if (hour > 23 || minute > 59) {
-    throw new Error(`時刻の範囲が不正です: ${value}`);
-  }
-  return { date, hour, minute };
-}
-
-function formatTime(time: Time): string {
-  return `${String(time.hour).padStart(2, '0')}:${String(time.minute).padStart(2, '0')}`;
 }
 
 /**
@@ -367,18 +342,6 @@ function buildCreateProject(row: CreateProjectRow): Project {
 /** 新規作成 1 件分。アイコンは企画を作った後に URL から取ってきて送る。 */
 type CreateEntry = { project: Project; iconUrl: string };
 
-function formatTags(project: Project): string {
-  if (project.type === 'food-stall') {
-    return project.tag
-      .map((tag) => ('tag2' in tag ? `${tag.tag}:${tag.tag2}` : tag.tag))
-      .join(';');
-  }
-  if (project.type === 'general') {
-    return project.tag.join(';');
-  }
-  return '';
-}
-
 function toRow(project: Project): ProjectRow {
   const day1 = project.occasions.find(
     (occasion) => occasion.timeRange.start.date === 1,
@@ -459,58 +422,9 @@ function parseCreateCsv(csv: string): Promise<CreateEntry[]> {
   });
 }
 
-/** events26 がアイコンとして受け付ける形式。ここに無いファイルは送らずに飛ばす。 */
-const ICON_CONTENT_TYPES = [
-  'image/png',
-  'image/jpeg',
-  'image/gif',
-  'image/webp',
-  'image/heic',
-];
-
-/** アイコン原本の公開 URL。events26 が認証なしで配信している。 */
-function iconUrl(projectId: string, cacheBuster: number): string {
-  return `${EVENTS26_API_URL}/v1/projects/${encodeURIComponent(projectId)}/icon?v=${cacheBuster}`;
-}
-
 /** `M-001.png` のようなファイル名から企画 ID(`M-001`)を取り出す。 */
 function projectIdFromFileName(fileName: string): string {
   return fileName.replace(/\.[^.]+$/, '');
-}
-
-/**
- * 応答が失敗ならエラーにする。
- *
- * openapi-fetch は本文の無い応答(`204` や `Content-Length: 0`)を成功・失敗に
- * かかわらず `{ error: undefined }` で返す。backend の失敗応答(403 / 404 / 415 /
- * 422 / 500)はいずれも本文が無いので、`error` だけを見ると失敗を成功と取り違える。
- * ステータスで判定し、本文があれば内容を添える。
- */
-function ensureOk(
-  result: { error?: unknown; response: Response },
-  label: string,
-): void {
-  if (result.response.ok) return;
-  const detail =
-    result.error === undefined ? '' : `: ${JSON.stringify(result.error)}`;
-  throw new Error(`${label}に失敗しました(${result.response.status})${detail}`);
-}
-
-/**
- * アイコンを 1 件 PUT する。
- *
- * events26 の `/admin/v1` は Cloudflare Access 配下なので backend 中継を通す。
- * ボディは画像そのもので JSON ではないため、openapi-fetch の既定シリアライザを
- * 素通しに差し替え、形式判定に使う `Content-Type` を明示する。
- */
-async function putIcon(projectId: string, image: Blob): Promise<void> {
-  const result = await api.PUT('/events26/projects/{project_id}/icon', {
-    params: { path: { project_id: projectId } },
-    body: image as unknown as string,
-    bodySerializer: (body: unknown) => body as BodyInit,
-    headers: { 'Content-Type': image.type },
-  });
-  ensureOk(result, 'アイコンのアップロード');
 }
 
 /**
@@ -814,6 +728,14 @@ function Events26Table() {
       title: <Tooltip title="projectName">企画名</Tooltip>,
       dataIndex: 'projectName',
       rowScope: 'row',
+      render: (value: string, record) => (
+        <a
+          style={{ textDecoration: 'underline' }}
+          href={`/events26/edit?project_id=${encodeURIComponent(record.id)}`}
+        >
+          {value}
+        </a>
+      ),
     },
     {
       key: 'description',
@@ -868,6 +790,13 @@ function Events26Table() {
       fixed: 'right',
       render: (value: string) => (
         <Flex gap={5}>
+          <Tooltip title="編集">
+            <Button
+              href={`/events26/edit?project_id=${encodeURIComponent(value)}`}
+            >
+              <EditOutlined />
+            </Button>
+          </Tooltip>
           <Popconfirm
             title="企画情報を削除"
             description="あなたは本当にこの企画情報を削除する気ですか！？"

--- a/apps/admin/src/features/events26/project.ts
+++ b/apps/admin/src/features/events26/project.ts
@@ -1,0 +1,118 @@
+/**
+ * 企画情報(events26)の一覧・編集で共有する型とヘルパー。
+ *
+ * CSV の読み書きは一覧側でしか使わないので [`Events26Page`] に残してある。
+ */
+import type { events26Components } from '@koudaisai/shared-types';
+import { EVENTS26_API_URL } from 'astro:env/client';
+import { api } from '@/features/api/api';
+
+export type Project = events26Components['schemas']['Project'];
+export type Occasion = events26Components['schemas']['Occasion'];
+export type Place = NonNullable<Occasion['place']>;
+export type Time = events26Components['schemas']['Time'];
+export type FoodStallTag = events26Components['schemas']['FoodStallTag'];
+export type GeneralTag = events26Components['schemas']['GeneralTag'];
+
+export const PROJECT_TYPE_LABEL: Record<
+  Project['type'],
+  { text: string; color: string }
+> = {
+  'food-stall': { text: '模擬店企画', color: 'red' },
+  general: { text: '一般企画', color: 'blue' },
+  stage: { text: 'ステージ企画', color: 'green' },
+  laboratory: { text: '研究室公開企画', color: 'orange' },
+};
+
+export const GENERAL_TAGS: GeneralTag[] = [
+  'experience',
+  'display',
+  'performance',
+  'food',
+  'lecture',
+];
+
+/** 模擬店タグの `tag` ごとに選べる `tag2`。`drink` は `tag2` を持たない。 */
+export const FOOD_STALL_TAG2: Record<'main' | 'sweet', string[]> = {
+  main: ['rice', 'noodle_flour', 'skewer_grill', 'snack', 'soup', 'world'],
+  sweet: ['japanese', 'western', 'cold', 'snack', 'drink', 'world'],
+};
+
+export function formatTime(time: Time): string {
+  return `${String(time.hour).padStart(2, '0')}:${String(time.minute).padStart(2, '0')}`;
+}
+
+/** `HH:MM` を `date` 日目の [`Time`] に変換する。 */
+export function parseTime(date: Time['date'], value: string): Time {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value.trim());
+  if (!match) {
+    throw new Error(`時刻は HH:MM 形式で指定してください: ${value}`);
+  }
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (hour > 23 || minute > 59) {
+    throw new Error(`時刻の範囲が不正です: ${value}`);
+  }
+  return { date, hour, minute };
+}
+
+export function formatTags(project: Project): string {
+  if (project.type === 'food-stall') {
+    return project.tag
+      .map((tag) => ('tag2' in tag ? `${tag.tag}:${tag.tag2}` : tag.tag))
+      .join(';');
+  }
+  if (project.type === 'general') {
+    return project.tag.join(';');
+  }
+  return '';
+}
+
+/** events26 がアイコンとして受け付ける形式。ここに無いファイルは送らずに飛ばす。 */
+export const ICON_CONTENT_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'image/heic',
+];
+
+/** アイコン原本の公開 URL。events26 が認証なしで配信している。 */
+export function iconUrl(projectId: string, cacheBuster: number): string {
+  return `${EVENTS26_API_URL}/v1/projects/${encodeURIComponent(projectId)}/icon?v=${cacheBuster}`;
+}
+
+/**
+ * 応答が失敗ならエラーにする。
+ *
+ * openapi-fetch は本文の無い応答(`204` や `Content-Length: 0`)を成功・失敗に
+ * かかわらず `{ error: undefined }` で返す。backend の失敗応答(403 / 404 / 415 /
+ * 422 / 500)はいずれも本文が無いので、`error` だけを見ると失敗を成功と取り違える。
+ * ステータスで判定し、本文があれば内容を添える。
+ */
+export function ensureOk(
+  result: { error?: unknown; response: Response },
+  label: string,
+): void {
+  if (result.response.ok) return;
+  const detail =
+    result.error === undefined ? '' : `: ${JSON.stringify(result.error)}`;
+  throw new Error(`${label}に失敗しました(${result.response.status})${detail}`);
+}
+
+/**
+ * アイコンを 1 件 PUT する。
+ *
+ * events26 の `/admin/v1` は Cloudflare Access 配下なので backend 中継を通す。
+ * ボディは画像そのもので JSON ではないため、openapi-fetch の既定シリアライザを
+ * 素通しに差し替え、形式判定に使う `Content-Type` を明示する。
+ */
+export async function putIcon(projectId: string, image: Blob): Promise<void> {
+  const result = await api.PUT('/events26/projects/{project_id}/icon', {
+    params: { path: { project_id: projectId } },
+    body: image as unknown as string,
+    bodySerializer: (body: unknown) => body as BodyInit,
+    headers: { 'Content-Type': image.type },
+  });
+  ensureOk(result, 'アイコンのアップロード');
+}

--- a/apps/admin/src/pages/events26/edit/index.astro
+++ b/apps/admin/src/pages/events26/edit/index.astro
@@ -1,0 +1,8 @@
+---
+import {EditProjectPage} from "@/features/events26/EditProjectPage";
+import DefaultLayout from "@/layouts/DefaultLayout.astro";
+---
+
+<DefaultLayout title="企画情報を編集">
+  <EditProjectPage client:load />
+</DefaultLayout>


### PR DESCRIPTION
## 概要

admin に企画情報（events26）を 1 件ずつ編集する画面を追加します。

これまで企画情報を直す手段は CSV の一括置き換えだけで、1 件の誤字を直すにも全件分の CSV を用意する必要がありました。`/events26/edit?project_id=M-001` で 1 件だけ編集できるようにします。既存の `notifications/edit`・`documents/edit` と同じ、クエリパラメータで対象を指定する作りに揃えています。

## 変更内容

- `apps/admin/src/pages/events26/edit/index.astro`（新規）— 編集ページ
- `apps/admin/src/features/events26/EditProjectPage.tsx`（新規）— 編集フォーム
  - 取得は events26 の公開エンドポイント `GET /v1/projects/{projectId}`（一覧と同じく backend に中継が無いため）、保存は backend 中継の `PUT /events26/projects/{project_id}`
  - 編集項目: 種類 / 団体名 / 企画名 / 概要 / 子供向け / おすすめ。種別に応じてラボツアー（研究室公開）とタグ（模擬店は `tag` + `tag2` の行リスト、一般は複数選択）
  - 開催予定は追加・削除可。実施場所は `GET /v1/places` から取った候補を検索付きで選ぶ（任意）。時刻は CSV と同じ `HH:mm` で入力し、形式をバリデーションする
  - PUT は差分更新ではなく全置き換えなので、種別を変えたときは元の種別だけが持つ項目（タグ・ラボツアー）を送らずに落とす
  - 企画番号は events26 側のキーなので読み取り専用
  - アイコンは企画本体と別 API のため、フォームの保存とは独立したカードで表示・アップロード・削除できる
- `apps/admin/src/features/events26/project.ts`（新規）— 一覧と編集で共有する型・ヘルパー（`ensureOk` / `putIcon` / `iconUrl` / `formatTime` / `parseTime` / `formatTags` / 種別ラベル / タグ定義）を切り出し。CSV の読み書きは一覧でしか使わないので `Events26Page.tsx` に残しています
- `apps/admin/src/features/events26/Events26Page.tsx` — 共有ヘルパーを import する形に整理し、企画名をリンク化 + 操作列に編集ボタンを追加

backend・OpenAPI 仕様の変更はありません（既存の中継エンドポイントのみを使用）。

## 確認したこと

- `npx nx lint admin`
- `npx tsc -b apps/admin/tsconfig.json`
- `npx prettier --check`

実サーバ（events26）への保存までの動作確認は行っていません。レビュー時にご確認ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)